### PR TITLE
Support SNI even when we don't want to check cn

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -646,6 +646,8 @@ main() {
 
         if [ -n "${COMMON_NAME}" ] ; then
             SERVERNAME="-servername ${COMMON_NAME}"
+        else
+            SERVERNAME="-servername ${HOST}"
         fi
 
     else


### PR DESCRIPTION
If we have a web server hosting multiple certs with SNI and some of these certs have wildcards, we still want to check expiry for known hostnames. Unless the -servername param is supplied to openssl with -servername, the wrong certificate would be delivered from the server.