### PR TITLE
handle wildcard certificates

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -853,10 +853,16 @@ EOF
     if [ -n "$COMMON_NAME" ] ; then
     
         ok=''
-    
-        case $COMMON_NAME in
-            $CN) ok='true' ;;
-        esac
+
+        if echo "$CN" | grep -q "^\*\." ; then
+            if echo "$COMMON_NAME" | grep -q "$(echo "$CN" | cut -c 3-)\$" ; then
+                ok='true'
+            fi
+        else
+            case $COMMON_NAME in
+                $CN) ok='true' ;;
+            esac
+        fi
     
         # check alterante names
         if [ -n "${ALTNAMES}" ] ; then


### PR DESCRIPTION
Suggestion how to handle wildcard certificates.
First it strips 1st character from CN value - asterisk, then in looks for that value in argument specified for the check.