### PR TITLE
Fix wildcard certificate match regex, add additional unit test

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -885,10 +885,10 @@ EOF
             fi
 
 	    # or the literal with the wildcard
-	    if echo "${COMMON_NAME}" | grep -q "^$(echo "${CN}" | sed -e 's/[.]/[.]/g' -e 's/[*]/[*]/' )\$" ; then
+	    if echo "${COMMON_NAME}" | grep -q "^$(echo "${CN}" | sed -e 's/[.]/[.]/g' -e 's/[*]/[A-Za-z0-9\-]*/' )\$" ; then
 
 		if [ -n "${DEBUG}" ] ; then
-		    echo "[DBG] the common name ${COMMON_NAME} matches ^$(echo "${CN}" | sed -e 's/[.]/[.]/g' -e 's/[*]/[*]/' )\$"
+		    echo "[DBG] the common name ${COMMON_NAME} matches ^$(echo "${CN}" | sed -e 's/[.]/[.]/g' -e 's/[*]/[A-Za-z0-9\-]*/' )\$"
 		fi
 		
                 ok='true'

--- a/test/unit_tests.sh
+++ b/test/unit_tests.sh
@@ -58,6 +58,12 @@ testETHZWildCard() {
     assertEquals "wrong exit code" ${NAGIOS_OK} "${EXIT_CODE}"
 }
 
+testETHZWildCardSub() {
+    ${SCRIPT} -H sherlock.sp.ethz.ch --cn sub.sp.ethz.ch --rootcert cabundle.crt
+    EXIT_CODE=$?
+    assertEquals "wrong exit code" ${NAGIOS_OK} "${EXIT_CODE}"
+}
+
 testAltNames() {
     ${SCRIPT} -H www.inf.ethz.ch --cn www.inf.ethz.ch --rootcert cabundle.crt --altnames
     EXIT_CODE=$?


### PR DESCRIPTION
Currently wildcard matching does not work for subdomains:

./check_ssl_cert -H en.wikipedia.org --cn en.wikipedia.org
SSL_CERT CRITICAL *.wikipedia.org: invalid CN ('*.wikipedia.org' does not match 'en.wikipedia.org')|days=262;;;;

It tries to match  '^[*][.]wikipedia[.]org$' for en.wikipedia.org

After fix:
./check_ssl_cert -H en.wikipedia.org --cn en.wikipedia.org
SSL_CERT OK - X.509 certificate for '*.wikipedia.org' from 'GlobalSign Organization Validation CA - SHA256 - G2' valid until Dec 10 22:46:04 2016 GMT (expires in 262 days)|days=262;;;;