### PR TITLE
Add BSD date support

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -815,8 +815,8 @@ main() {
 
     PERL="$(which perl 2> /dev/null)"
     DATEBIN="$(which date 2> /dev/null)"
+    DATETYPE=""
     if ! $DATEBIN +%s >/dev/null 2>&1; then
-        DATEBIN=""
         # Perl with Date::Parse (optional)
         test -x "${PERL}" || PERL=""
         if [ -z "${PERL}" ] && [ -n "${VERBOSE}" ] ; then
@@ -828,7 +828,6 @@ main() {
             if [ -n "${VERBOSE}" ] ; then
                 echo "Perl module Date::Parse not installed: disabling date computations"
             fi
-           PERL=""
 
         else
 
@@ -836,12 +835,20 @@ main() {
                 echo "Perl module Date::Parse installed: enabling date computations"
             fi
 
+        DATETYPE="PERL"
+
         fi
 
     else
 
+    if $DATEBIN --version >/dev/null 2>&1 ; then
+        DATETYPE="GNU"
+    else
+        DATETYPE="BSD"
+    fi
+
         if [ -n "${VERBOSE}" ] ; then
-            echo "Found date with timestamp support: enabling date computations"
+            echo "Found ${DATETYPE} date with timestamp support: enabling date computations"
         fi
 
     fi
@@ -1061,30 +1068,36 @@ main() {
 
     ################################################################################
     # Compute for how many days the certificate will be valid
-    if [ -n "${PERL}" ] || [ -n "${DATEBIN}" ]; then
+    if [ -n "${DATETYPE}" ]; then
 
         CERT_END_DATE=$($OPENSSL x509 -in "${CERT}" -noout -enddate | sed -e "s/.*=//")
 
-        if [ -n "${DATEBIN}" ]; then
+        OLDLANG=$LANG
+        LANG=en_US
 
-            DAYS_VALID=$(( ( $(${DATEBIN} -d "${CERT_END_DATE}" +%s) - $(${DATEBIN} +%s) ) / 86400 ))
+        case "${DATETYPE}" in
+            "BSD")
+                DAYS_VALID=$(( ( $(${DATEBIN} -jf "%b %d %T %Y %Z" "${CERT_END_DATE}" +%s) - $(${DATEBIN} +%s) ) / 86400 ))
+                ;;
 
-        else
-        
-            DAYS_VALID=$(perl - "${CERT_END_DATE}" <<-"EOF"
-			    use strict;
-			    use warnings;
+            "GNU")
+                DAYS_VALID=$(( ( $(${DATEBIN} -d "${CERT_END_DATE}" +%s) - $(${DATEBIN} +%s) ) / 86400 ))
+                ;;
 
-			    use Date::Parse;
+            "PERL")
+				DAYS_VALID=$(perl - "${CERT_END_DATE}" <<-"EOF"
+					use strict;
+					use warnings;
+					use Date::Parse;
+					my $cert_date = str2time( $ARGV[0] );
+					my $days = int (( $cert_date - time ) / 86400 + 0.5);
+					print "$days\n";
+				EOF
+				)
+				;;
+        esac
 
-			    my $cert_date = str2time( $ARGV[0] );
-
-			    my $days = int (( $cert_date - time ) / 86400 + 0.5);
-
-			    print "$days\n";
-			EOF
-            )
-        fi
+        LANG=$OLDLANG
 
         if [ -n "${VERBOSE}" ] ; then
 


### PR DESCRIPTION
BSD date (on *BSD, Mac and others) does not support linux style -d date conversion. Added detection and support of BSD style date.