### PR TITLE
Fix "openssl ocsp -header" support detection

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -1406,7 +1406,10 @@ main() {
 
 	# check if -header is supported
 	OCSP_HEADER=""
-	if "${OPENSSL}" ocsp 2>&1 | grep -q -- -header ; then
+
+	# oscp -header is supported in OpenSSL versions from 1.0.0, but not documented until 1.1.0
+	# so we check if the major version is greater than 0
+	if [ $( ${OPENSSL} version | sed -e 's/OpenSSL \([0-9]\).*/\1/g' )  -gt 0 ]; then
 
 	    if [ -n "${DEBUG}" ] ; then
 		echo "[DBG] openssl ocsp support the -header option"


### PR DESCRIPTION
openssl oscp -header is supported in OpenSSL versions from 1.0.0, but not documented until 1.1.0

See:
* https://github.com/openssl/openssl/commit/0c690586e053fe149e91a3f759d9789fbce0b714
* https://github.com/openssl/openssl/commit/7e1b7485706c2b11091b5fa897fe496a2faa56cc
