### PR TITLE
Add support for checking revocation by OCSP via http proxy

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -1469,7 +1469,11 @@ main() {
 		echo "[DBG] executing $OPENSSL ocsp -no_nonce -issuer ${ISSUER_CERT} -cert ${CERT}  -url ${OCSP_URI} ${OCSP_HEADER} -header HOST ${OCSP_HOST}"
 	    fi
 	
-            OCSP_RESP="$($OPENSSL ocsp -no_nonce -issuer "${ISSUER_CERT}" -cert "${CERT}" -url "${OCSP_URI}" -header HOST "${OCSP_HOST}" 2>&1 | grep -i "ssl_cert")"
+            if [ -n "${HTTP_PROXY:-}" ] ; then
+                OCSP_RESP="$($OPENSSL ocsp -no_nonce -issuer "${ISSUER_CERT}" -cert "${CERT}" -host "${HTTP_PROXY#*://}" -path "${OCSP_URI}" -header HOST "${OCSP_HOST}" 2>&1 | grep -i "ssl_cert")"
+            else
+                OCSP_RESP="$($OPENSSL ocsp -no_nonce -issuer "${ISSUER_CERT}" -cert "${CERT}" -url "${OCSP_URI}" -header HOST "${OCSP_HOST}" 2>&1 | grep -i "ssl_cert")"
+            fi
 	    
 	    if [ -n "${DEBUG}" ] ; then
 		echo "[DBG] OCSP: response = ${OCSP_RESP}"	
@@ -1479,7 +1483,11 @@ main() {
 		critical "certificate is revoked"
             elif ! echo "${OCSP_RESP}" | grep -qi "good" ; then	    
 	    
-		OCSP_RESP="$($OPENSSL ocsp -no_nonce -issuer "${ISSUER_CERT}" -cert "${CERT}" -url "${OCSP_URI}" "${OCSP_HEADER}" 2>&1 )"
+                if [ -n "${HTTP_PROXY:-}" ] ; then
+                    OCSP_RESP="$($OPENSSL ocsp -no_nonce -issuer "${ISSUER_CERT}" -cert "${CERT}" -host "${HTTP_PROXY#*://}" -path "${OCSP_URI}" "${OCSP_HEADER}" 2>&1 )"
+                else
+                    OCSP_RESP="$($OPENSSL ocsp -no_nonce -issuer "${ISSUER_CERT}" -cert "${CERT}" -url "${OCSP_URI}" "${OCSP_HEADER}" 2>&1 )"
+                fi
 		critical "${OCSP_RESP}"
 	    
 	    fi


### PR DESCRIPTION
The `openssl` command doesn't support the HTTP_PROXY environment variable directly, so it is necessary to use a different calling syntax if an HTTP proxy is to be used.  See: https://groups.google.com/forum/#!topic/mailing.openssl.users/dajh2puIxz8

This short pull request checks for the presence of an HTTP_PROXY environment variable and calls `openssl` with the alternative syntax for the OCSP check if it is set.