### PR TITLE
Support for check of multiple cn's in altnames

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -596,7 +596,11 @@ main() {
                ;;
             -n|--cn)
                 if [ $# -gt 1 ]; then
-                    COMMON_NAME="${COMMON_NAME} ${2}"
+		    if [ -n "${COMMON_NAME}" ]; then
+		      COMMON_NAME="${COMMON_NAME} ${2}"
+		    else
+                      COMMON_NAME="${2}"
+		    fi
                     shift 2
                 else
                     unknown "-n,--cn requires an argument"

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -596,7 +596,7 @@ main() {
                ;;
             -n|--cn)
                 if [ $# -gt 1 ]; then
-                    COMMON_NAME="$2"
+                    COMMON_NAME="${COMMON_NAME} ${2}"
                     shift 2
                 else
                     unknown "-n,--cn requires an argument"
@@ -1242,24 +1242,39 @@ main() {
         # Check alterante names
         if [ -n "${ALTNAMES}" ] ; then
 
-            if [ -n "${DEBUG}" ] ; then
-                echo "[DBG] checking altnames"
-            fi
+            for cn in ${COMMON_NAME} ; do
 
-            for alt_name in $($OPENSSL x509 -in "${CERT}" -text \
-                | grep --after-context=1 "509v3 Subject Alternative Name:" \
-                | tail -n 1 | sed -e "s/DNS://g" | sed -e "s/,//g") ; do
+                ok=""
 
                 if [ -n "${DEBUG}" ] ; then
-                    echo "[DBG]   ${alt_name}"
+                    echo "[DBG] checking altnames against ${cn}"
                 fi
 
-		if echo "${COMMON_NAME}" | grep -q -i "^${alt_name}$" ; then
-                    ok="true"
-		fi
+                for alt_name in $($OPENSSL x509 -in "${CERT}" -text \
+                    | grep --after-context=1 "509v3 Subject Alternative Name:" \
+                    | tail -n 1 | sed -e "s/DNS://g" | sed -e "s/,//g") ; do
+
+                    if [ -n "${DEBUG}" ] ; then
+                        echo "[DBG]   ${alt_name}"
+                    fi
+
+		    if echo "${cn}" | grep -q -i "^${alt_name}$" ; then
+                        ok="true"
+		    fi
+
+                done
+
+                if [ -z "$ok" ] ; then
+                    fail=$cn
+                    break;
+                fi
 
             done
 
+        fi
+
+        if [ -n "$fail" ] ; then
+           critical "invalid CN ('$CN' does not match '$fail')"
         fi
 
         if [ -z "$ok" ] ; then

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -933,7 +933,7 @@ main() {
     SERVERNAME=
     if ${OPENSSL} s_client not_a_real_option 2>&1 | grep -q -- -servername ; then
 
-        if [ -n "${COMMON_NAME}" ] ; then
+        if [ -n "${COMMON_NAME}" ] && [ "${COMMON_NAME}" == "${COMMON_NAME// /}" ] ; then
             SERVERNAME="-servername ${COMMON_NAME}"
         else
             SERVERNAME="-servername ${HOST}"

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -933,7 +933,7 @@ main() {
     SERVERNAME=
     if ${OPENSSL} s_client not_a_real_option 2>&1 | grep -q -- -servername ; then
 
-        if [ -n "${COMMON_NAME}" ] && [ "${COMMON_NAME}" == "${COMMON_NAME// /}" ] ; then
+        if [ -n "${COMMON_NAME}" ] && [ "${COMMON_NAME}" = "$(echo "${COMMON_NAME}" | tr -d' ')" ] ; then
             SERVERNAME="-servername ${COMMON_NAME}"
         else
             SERVERNAME="-servername ${HOST}"

--- a/test/unit_tests.sh
+++ b/test/unit_tests.sh
@@ -105,6 +105,27 @@ testAltNames2() {
     assertEquals "wrong exit code" ${NAGIOS_CRITICAL} "${EXIT_CODE}"
 }
 
+testMultipleAltNamesOK() {
+    # Test with multiple CN's
+    ${SCRIPT} -H inf.ethz.ch -n www.ethz.ch -n ethz.ch --rootcert cabundle.crt --altnames
+    EXIT_CODE=$?
+    assertEquals "wrong exit code" ${NAGIOS_OK} "${EXIT_CODE}"
+}
+
+testMultipleAltNamesFailOne() {
+    # Test with wiltiple CN's but last one is wrong
+    ${SCRIPT} -H inf.ethz.ch -n www.ethz.ch -n wrong.ch --rootcert cabundle.crt --altnames
+    EXIT_CODE=$?
+    assertEquals "wrong exit code" ${NAGIOS_CRITICAL} "${EXIT_CODE}"
+}
+
+testMultipleAltNamesFailTwo() {
+    # Test with multiple CN's but first one is wrong
+    ${SCRIPT} -H inf.ethz.ch -n wrong.ch -n www.ethz.ch --rootcert cabundle.crt --altnames
+    EXIT_CODE=$?
+    assertEquals "wrong exit code" ${NAGIOS_CRITICAL} "${EXIT_CODE}"
+}
+
 testAltNames2CaseInsensitive() {
     # should fail: inf.ethz.ch has the same ip as www.inf.ethz.ch but inf.ethz.ch is not in the certificate
     ${SCRIPT} -H inf.ethz.ch --cn INF.ETHZ.CH --rootcert cabundle.crt --altnames


### PR DESCRIPTION
I want to have an option to verify multiple cn's in the altnames. With this change it is possible to add multiple times the option -n which will check, for each -n option given, if it exists in altnames. Once a check fail it will exit with critical status.