### PR TITLE
Wildcard support in Alternative Names

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -1250,7 +1250,7 @@ main() {
         fi
 
         # Check alterante names
-        if [ -n "${ALTNAMES}" ] ; then
+        if [ -n "${ALTNAMES}" ] && [ -z "$ok" ]; then
 
             for cn in ${COMMON_NAME} ; do
 

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -1265,12 +1265,58 @@ main() {
                     | tail -n 1 | sed -e "s/DNS://g" | sed -e "s/,//g") ; do
 
                     if [ -n "${DEBUG}" ] ; then
-                        echo "[DBG]   ${alt_name}"
+                        echo "[DBG] check Altname: ${alt_name}"
                     fi
 
-		    if echo "${cn}" | grep -q -i "^${alt_name}$" ; then
-                        ok="true"
-		    fi
+                    if echo "${alt_name}" | grep -q -i "^\*\." ; then
+
+                        # Match the domain
+                        if [ -n "${DEBUG}" ] ; then
+                            echo "[DBG] the altname ${alt_name} begins with a '*'"
+                            echo "[DBG] checking if the common name matches ^$(echo "${alt_name}" | cut -c 3-)\$"
+                        fi
+                        if echo "${cn}" | grep -q -i "^$(echo "${alt_name}" | cut -c 3-)\$" ; then
+                            if [ -n "${DEBUG}" ] ; then
+                                echo "[DBG] the common name ${cn} matches ^$( echo "${alt_name}" | cut -c 3- )\$"
+                            fi
+                            ok="true"
+
+                        fi
+
+                        # Or the literal with the wildcard
+                        if [ -n "${DEBUG}" ] ; then
+                            echo "[DBG] checking if the common name matches ^$(echo "${alt_name}" | sed -e 's/[.]/[.]/g' -e 's/[*]/[A-Za-z0-9\-]*/' )\$"
+                        fi
+                        if echo "${cn}" | grep -q -i "^$(echo "${alt_name}" | sed -e 's/[.]/[.]/g' -e 's/[*]/[A-Za-z0-9\-]*/' )\$" ; then
+                            if [ -n "${DEBUG}" ] ; then
+                                echo "[DBG] the common name ${cn} matches ^$(echo "${alt_name}" | sed -e 's/[.]/[.]/g' -e 's/[*]/[A-Za-z0-9\-]*/' )\$"
+                            fi
+                            ok="true"
+                        fi
+
+                        # Or if both are exactly the same
+                        if [ -n "${DEBUG}" ] ; then
+                            echo "[DBG] checking if the common name matches ^${alt_name}\$"
+                        fi
+                        if echo "${cn}" | grep -q -i "^${alt_name}\$" ; then
+                            if [ -n "${DEBUG}" ] ; then
+                                echo "[DBG] the common name ${cn} matches ^${alt_name}\$"
+                            fi
+                            ok="true"
+                        fi
+
+                    else
+
+                        if echo "${cn}" | grep -q -i "^${alt_name}$" ; then
+                            ok="true"
+                        fi
+
+                    fi
+
+                    if [ -n "$ok" ] ; then
+                        #fail=$cn
+                        break;
+                    fi
 
                 done
 

--- a/test/unit_tests.sh
+++ b/test/unit_tests.sh
@@ -98,6 +98,17 @@ testWildcardAltNames1() {
     assertEquals "wrong exit code" ${NAGIOS_OK} "${EXIT_CODE}"
 }
 
+#Check for wildcard support in Alternative Names
+testWildcardAltNames2() {
+    ${SCRIPT} -H sherlock.sp.ethz.ch \
+        --cn somehost.spapps.ethz.ch \
+        --cn otherhost.sPaPPs.ethz.ch \
+        --cn spapps.ethz.ch \
+        --rootcert cabundle.crt --altnames
+    EXIT_CODE=$?
+    assertEquals "wrong exit code" ${NAGIOS_OK} "${EXIT_CODE}"
+}
+
 testAltNamesCaseInsensitve() {
     ${SCRIPT} -H www.inf.ethz.ch --cn WWW.INF.ETHZ.CH --rootcert cabundle.crt --altnames
     EXIT_CODE=$?

--- a/test/unit_tests.sh
+++ b/test/unit_tests.sh
@@ -91,6 +91,12 @@ testAltNames() {
     assertEquals "wrong exit code" ${NAGIOS_OK} "${EXIT_CODE}"
 }
 
+#Do not require to match Alternative Name if CN already matched
+testWildcardAltNames1() {
+    ${SCRIPT} -H sherlock.sp.ethz.ch --rootcert cabundle.crt --altnames --host-cn
+    EXIT_CODE=$?
+    assertEquals "wrong exit code" ${NAGIOS_OK} "${EXIT_CODE}"
+}
 
 testAltNamesCaseInsensitve() {
     ${SCRIPT} -H www.inf.ethz.ch --cn WWW.INF.ETHZ.CH --rootcert cabundle.crt --altnames


### PR DESCRIPTION
Fix for issue #36.

```
check_ssl_cert  -H sherlock.sp.ethz.ch \
        --cn somehost.spapps.ethz.ch \
        --cn otherhost.spapps.ethz.ch \
        --cn spapps.ethz.ch \
        --rootcert cabundle.crt --altnames -d
...
[DBG] check CN: *.sp.ethz.ch
[DBG] the common name *.sp.ethz.ch begins with a '*'
[DBG] checking if the common name matches ^sp.ethz.ch$
[DBG] checking if the common name matches ^[A-Za-z0-9-]*[.]sp[.]ethz[.]ch$
[DBG] checking if the common name matches ^*.sp.ethz.ch$
[DBG] checking altnames against somehost.spapps.ethz.ch
[DBG] check Altname: *.sp.ethz.ch
[DBG] the altname *.sp.ethz.ch begins with a '*'
[DBG] checking if the common name matches ^sp.ethz.ch$
[DBG] checking if the common name matches ^[A-Za-z0-9-]*[.]sp[.]ethz[.]ch$
[DBG] checking if the common name matches ^*.sp.ethz.ch$
[DBG] check Altname: sp.ethz.ch
[DBG] check Altname: *.spapps.ethz.ch
[DBG] the altname *.spapps.ethz.ch begins with a '*'
[DBG] checking if the common name matches ^spapps.ethz.ch$
[DBG] checking if the common name matches ^[A-Za-z0-9-]*[.]spapps[.]ethz[.]ch$
[DBG] the common name somehost.spapps.ethz.ch matches ^[A-Za-z0-9-]*[.]spapps[.]ethz[.]ch$
[DBG] checking if the common name matches ^*.spapps.ethz.ch$
[DBG] checking altnames against otherhost.spapps.ethz.ch
[DBG] check Altname: *.sp.ethz.ch
[DBG] the altname *.sp.ethz.ch begins with a '*'
[DBG] checking if the common name matches ^sp.ethz.ch$
[DBG] checking if the common name matches ^[A-Za-z0-9-]*[.]sp[.]ethz[.]ch$
[DBG] checking if the common name matches ^*.sp.ethz.ch$
[DBG] check Altname: sp.ethz.ch
[DBG] check Altname: *.spapps.ethz.ch
[DBG] the altname *.spapps.ethz.ch begins with a '*'
[DBG] checking if the common name matches ^spapps.ethz.ch$
[DBG] checking if the common name matches ^[A-Za-z0-9-]*[.]spapps[.]ethz[.]ch$
[DBG] the common name otherhost.spapps.ethz.ch matches ^[A-Za-z0-9-]*[.]spapps[.]ethz[.]ch$
[DBG] checking if the common name matches ^*.spapps.ethz.ch$
[DBG] checking altnames against spapps.ethz.ch
[DBG] check Altname: *.sp.ethz.ch
[DBG] the altname *.sp.ethz.ch begins with a '*'
[DBG] checking if the common name matches ^sp.ethz.ch$
[DBG] checking if the common name matches ^[A-Za-z0-9-]*[.]sp[.]ethz[.]ch$
[DBG] checking if the common name matches ^*.sp.ethz.ch$
[DBG] check Altname: sp.ethz.ch
[DBG] check Altname: *.spapps.ethz.ch
[DBG] the altname *.spapps.ethz.ch begins with a '*'
[DBG] checking if the common name matches ^spapps.ethz.ch$
[DBG] the common name spapps.ethz.ch matches ^spapps.ethz.ch$
[DBG] checking if the common name matches ^[A-Za-z0-9-]*[.]spapps[.]ethz[.]ch$
[DBG] checking if the common name matches ^*.spapps.ethz.ch$
[DBG] CN check finished
```