### PR TITLE
'--altnames' option and plugin output

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -1777,10 +1777,13 @@ main() {
     ################################################################################
     # If we get this far, assume all is well. :)
 
-    # If --altnames was specified we show the specified CN instead of
-    # the certificate CN
-    if [ -n "${ALTNAMES}" ] && [ -n "${COMMON_NAME}" ] ; then
-        CN=${COMMON_NAME}
+    # If --altnames was specified or if the certificate is wildcard,
+    # then we show the specified CN in addition to the certificate CN
+    CHECKEDNAMES=""
+    if [ -n "${ALTNAMES}" ] && [ -n "${COMMON_NAME}" ] && [ "${CN}" != "${COMMON_NAME}" ]; then
+        CHECKEDNAMES="(${COMMON_NAME}) "
+    elif [ -n "${COMMON_NAME}" ] && echo "${CN}" | grep -q -i "^\*\." ; then
+        CHECKEDNAMES="(${COMMON_NAME}) "
     fi
 
     if [ -n "${DAYS_VALID}" ] ; then
@@ -1802,7 +1805,7 @@ main() {
         SSL_LABS_HOST_GRADE=", SSL Labs grade: ${SSL_LABS_HOST_GRADE}"
     fi
 
-    echo "${SHORTNAME} OK - X.509 ${SELFSIGNEDCERT}certificate for '${CN}' from '${CA_ISSUER_MATCHED}' valid until ${DATE}${DAYS_VALID}${SSL_LABS_HOST_GRADE}${PERFORMANCE_DATA}${LONG_OUTPUT}"
+    echo "${SHORTNAME} OK - X.509 ${SELFSIGNEDCERT}certificate '${CN}' ${CHECKEDNAMES}from '${CA_ISSUER_MATCHED}' valid until ${DATE}${DAYS_VALID}${SSL_LABS_HOST_GRADE}${PERFORMANCE_DATA}${LONG_OUTPUT}"
 
     exit 0
 


### PR DESCRIPTION
Typical plugin use is to check if service certificate is suitable to service hostname.
So, `--cn` or `--host-cn` option must be used.

At other side, certificates with altnames or wildcard certificates also used commonly.

So, configuration of typical service check in Nagios looks like:

`check_ssl_cert -H $HOSTNAME$ --host-cn --altnames --warning ...  --critical ...`

Use of `--altnames` option changes the output from certificate CN to checked hostname.
As result, CN of the certificate is missing in plugin output and there is no way to identify service certificate by CN.

From my point of view, certificate CN should be in plugin output all the time.
If needed, checked hostnames can be set in service name (in configuration), so notifications and status page will have all required information.

There is two solutions of this:

1) Do not override CN and do not output COMMON_NAME at all.

```
-    # If --altnames was specified we show the specified CN instead of
-    # the certificate CN
-    if [ -n "${ALTNAMES}" ] && [ -n "${COMMON_NAME}" ] ; then
-        CN=${COMMON_NAME}
-    fi
```

2) Show checked names after certificate common name (this patch).

(Showing of checked names allows to find configuration issues by comparing plugin output with service name.)

Before the patch:

```
# ./check_ssl_cert -H mail.domain.tld
SSL_CERT OK - X.509 certificate for '*.domain.tld' from 'ISSUER' valid until Dec  9 23:59:59 2017 GMT (expires in 305 days)|days=305;;;;

# ./check_ssl_cert -H mail.domain.tld --host-cn
SSL_CERT OK - X.509 certificate for '*.domain.tld' from 'ISSUER' valid until Dec  9 23:59:59 2017 GMT (expires in 305 days)|days=305;;;;

# ./check_ssl_cert -H mail.domain.tld --host-cn --altnames
SSL_CERT OK - X.509 certificate for 'mail.domain.tld' from 'ISSUER' valid until Dec  9 23:59:59 2017 GMT (expires in 305 days)|days=305;;;;

# ./check_ssl_cert -H mail.domain.tld -n mail.domain.tld
SSL_CERT OK - X.509 certificate for '*.domain.tld' from 'ISSUER' valid until Dec  9 23:59:59 2017 GMT (expires in 305 days)|days=305;;;;

# ./check_ssl_cert -H mail.domain.tld -n mail.domain.tld --altnames
SSL_CERT OK - X.509 certificate for 'mail.domain.tld' from 'ISSUER' valid until Dec  9 23:59:59 2017 GMT (expires in 305 days)|days=305;;;;

# ./check_ssl_cert -H mail.domain.tld -n mail.domain.tld -n test.domain.tld --altnames
SSL_CERT OK - X.509 certificate for 'mail.domain.tld test.domain.tld' from 'ISSUER' valid until Dec  9 23:59:59 2017 GMT (expires in 305 days)|days=305;;;;
```
All these checks are to `*.domain.tld` certificate, but that is not clear from checks output.

After the patch, things becomes more clear:

```
# ./check_ssl_cert -H mail.domain.tld
SSL_CERT OK - X.509 certificate '*.domain.tld' from 'ISSUER' valid until Dec  9 23:59:59 2017 GMT (expires in 305 days)|days=305;;;;

# ./check_ssl_cert -H mail.domain.tld --host-cn
SSL_CERT OK - X.509 certificate '*.domain.tld' (mail.domain.tld) from 'ISSUER' valid until Dec  9 23:59:59 2017 GMT (expires in 305 days)|days=305;;;;

# ./check_ssl_cert -H mail.domain.tld --host-cn --altnames
SSL_CERT OK - X.509 certificate '*.domain.tld' (mail.domain.tld) from 'ISSUER' valid until Dec  9 23:59:59 2017 GMT (expires in 305 days)|days=305;;;;

# ./check_ssl_cert -H mail.domain.tld -n mail.domain.tld
SSL_CERT OK - X.509 certificate '*.domain.tld' (mail.domain.tld) from 'ISSUER' valid until Dec  9 23:59:59 2017 GMT (expires in 305 days)|days=305;;;;

# ./check_ssl_cert -H mail.domain.tld -n mail.domain.tld --altnames
SSL_CERT OK - X.509 certificate '*.domain.tld' (mail.domain.tld) from 'ISSUER' valid until Dec  9 23:59:59 2017 GMT (expires in 305 days)|days=305;;;;

# ./check_ssl_cert -H mail.domain.tld -n mail.domain.tld -n test.domain.tld --altnames
SSL_CERT OK - X.509 certificate '*.domain.tld' (mail.domain.tld test.domain.tld) from 'ISSUER' valid until Dec  9 23:59:59 2017 GMT (expires in 305 days)|days=305;;;;
```
Also, output of check with `--altnames` option in use is equal to check output without it.

What do you think about such change?