### PR TITLE
Use openssl s_client's -help option to test for SNI support

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -979,9 +979,12 @@ main() {
     # Check if openssl s_client supports the -servername option
     #
     #   openssl s_client now has a -help option, so we can use that.
+    #   Some older versions support -servername, but not -help
+    #   => We supply an invalid command line option to get the help
+    #      on standard error for these intermediate versions.
     #
     SERVERNAME=
-    if ${OPENSSL} s_client -help 2>&1 | grep -q -- -servername ; then
+    if ${OPENSSL} s_client -help 2>&1 | grep -q -- -servername || ${OPENSSL} s_client not_a_real_option 2>&1 | grep -q -- -servername; then
 
 	if [ -n "${SNI}" ]; then
 	    SERVERNAME="-servername ${SNI}"

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -978,12 +978,10 @@ main() {
     ################################################################################
     # Check if openssl s_client supports the -servername option
     #
-    #   openssl s_client does not have a -help option
-    #   => We supply an invalid command line option to get the help
-    #      on standard error
+    #   openssl s_client now has a -help option, so we can use that.
     #
     SERVERNAME=
-    if ${OPENSSL} s_client not_a_real_option 2>&1 | grep -q -- -servername ; then
+    if ${OPENSSL} s_client -help 2>&1 | grep -q -- -servername ; then
 
 	if [ -n "${SNI}" ]; then
 	    SERVERNAME="-servername ${SNI}"


### PR DESCRIPTION
Since https://github.com/openssl/openssl/commit/7e1b7485706c2b11091b5fa897fe496a2faa56cc s_client no longer returns usage information in response to invalid command lines. It also has a -help option now.