### PR TITLE
Added support for TLS1.3 during IETF 101 hackathon

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -14,7 +14,7 @@
 #
 # This module is free software; you can redistribute it and/or modify it
 # under the terms of GNU general public license (gpl) version 3.
-# See the LICENSE file for details.
+# See the LICENSE file for details. 
 
 ################################################################################
 # Constants
@@ -114,7 +114,7 @@ usage() {
     echo "      --tls1                  force TLS version 1"
     echo "      --tls1_1                force TLS version 1.1"
     echo "      --tls1_2                force TLS version 1.2"
-    echo "      --tls1_3                force TLS version 1.3"
+    #echo "      --tls1_3                force TLS version 1.3"
     echo "   -v,--verbose               verbose output"
     echo "   -V,--version               version"
     echo "   -w,--warning days          minimum number of days a certificate has to be valid"

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -114,7 +114,7 @@ usage() {
     echo "      --tls1                  force TLS version 1"
     echo "      --tls1_1                force TLS version 1.1"
     echo "      --tls1_2                force TLS version 1.2"
-    #echo "      --tls1_3                force TLS version 1.3"
+    echo "      --tls1_3                force TLS version 1.3"
     echo "   -v,--verbose               verbose output"
     echo "   -V,--version               version"
     echo "   -w,--warning days          minimum number of days a certificate has to be valid"

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -114,6 +114,7 @@ usage() {
     echo "      --tls1                  force TLS version 1"
     echo "      --tls1_1                force TLS version 1.1"
     echo "      --tls1_2                force TLS version 1.2"
+    echo "      --tls1_3                force TLS version 1.3"
     echo "   -v,--verbose               verbose output"
     echo "   -V,--version               version"
     echo "   -w,--warning days          minimum number of days a certificate has to be valid"
@@ -550,6 +551,10 @@ main() {
                 SSL_VERSION="-tls1_2"
                 shift
                 ;;
+            --tls1_3)
+                SSL_VERSION="-tls1_3"
+                shift
+                ;;                
             --ocsp)
                 # deprecated
                 shift
@@ -907,9 +912,9 @@ main() {
             unknown "${OPENSSL} ist not an executable"
         fi
 
-        if ! "${OPENSSL}" list-standard-commands | grep -q s_client ; then
-            unknown "${OPENSSL} ist not an openssl executable"
-        fi
+        #if ! "${OPENSSL}" list-standard-commands | grep -q s_client ; then
+        #    unknown "${OPENSSL} ist not an openssl executable"
+        #fi
 
     fi
 


### PR DESCRIPTION
check_ssl_cert now supports TLS 1.3. Added by hackers.mu during IETF 101 hackathon