### PR TITLE
add --terse option and fix minor typo in help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Options:
    -r,--rootcert path         root certificate or directory to be used for
                               certificate validation
       --rsa                   cipher selection: force RSA authentication
+      --terse                 terse output
    -t,--timeout               seconds timeout after the specified time
                               (defaults to 15 seconds)
       --temp dir              directory where to store the temporary files

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -107,7 +107,7 @@ usage() {
     echo "                              extension"
     echo "   -r,--rootcert path         root certificate or directory to be used for"
     echo "                              certificate validation"
-    echo "       --rsa                  cipher selection: force RSA authentication"
+    echo "      --rsa                   cipher selection: force RSA authentication"
     echo "      --terse                 terse output"
     echo "   -t,--timeout               seconds timeout after the specified time"
     echo "                              (defaults to 15 seconds)"

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -108,6 +108,7 @@ usage() {
     echo "   -r,--rootcert path         root certificate or directory to be used for"
     echo "                              certificate validation"
     echo "       --rsa                  cipher selection: force RSA authentication"
+    echo "      --terse                 terse output"
     echo "   -t,--timeout               seconds timeout after the specified time"
     echo "                              (defaults to 15 seconds)"
     echo "      --temp dir              directory where to store the temporary files"
@@ -561,6 +562,10 @@ main() {
                 ;;
             --ignore-ocsp)
                 OCSP=""
+                shift
+                ;;
+            --terse)
+                TERSE=1
                 shift
                 ;;
             -v|--verbose)
@@ -2135,7 +2140,12 @@ EOF
         DISPLAY_CN="'${CN}' "
     fi
 
-    echo "${SHORTNAME} OK - ${OPENSSL_COMMAND} ${SELFSIGNEDCERT}certificate ${DISPLAY_CN}${CHECKEDNAMES}from '${CA_ISSUER_MATCHED}' valid until ${DATE}${DAYS_VALID}${SSL_LABS_HOST_GRADE}${PERFORMANCE_DATA}${LONG_OUTPUT}"
+
+    if [ -n "${TERSE}" ]; then
+        echo "${SHORTNAME} OK ${CN} ${DAYS_VALID}"
+    else 
+        echo "${SHORTNAME} OK - ${OPENSSL_COMMAND} ${SELFSIGNEDCERT}certificate ${DISPLAY_CN}${CHECKEDNAMES}from '${CA_ISSUER_MATCHED}' valid until ${DATE}${DAYS_VALID}${SSL_LABS_HOST_GRADE}${PERFORMANCE_DATA}${LONG_OUTPUT}"
+    fi
 
     exit 0
 

--- a/check_ssl_cert.1
+++ b/check_ssl_cert.1
@@ -142,6 +142,9 @@ root certificate or directory to be used for certficate validation (passed to op
 .BR "   --rsa"
 cipher selection: force RSA authentication
 .TP
+.BR "   --terse"
+terse output (also see --verbose) 
+.TP
 .BR "-t,--timeout"
 seconds timeout after the specified time (defaults to 15 seconds)
 .TP
@@ -161,7 +164,7 @@ force TLS version 1.2
 force TLS version 1.3
 .TP
 .BR "-v,--verbose"
-verbose output
+verbose output (also see --terse)
 .TP
 .BR "-V,--version"
 version


### PR DESCRIPTION
Hi, thanks so much for this script.  It's great.

I modified it to add a "--terse" option, so the output is shorter and doesn't line-wrap on my nagios web pages.  I suppose "choose your own output" would have been better.  

Also corrected spacing issue in --help output.

Also, I noticed that in the --help text, the options are not quite in alphabetical order (S options would fall between R and T).  I didn't correct that in case it was on purpose.  