### PR TITLE
Add POP3S as protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Options:
       --openssl path          path of the openssl binary to be used
    -p,--port port             TCP port
    -P,--protocol protocol     use the specific protocol
-                              {http|smtp|pop3|imap|ftp|xmpp|irc|ldap}
+                              {http|smtp|pop3|imap|imaps|ftp|xmpp|irc|ldap}
                               http:                    default
                               smtp,pop3,imap,ftp,ldap: switch to TLS
    -s,--selfsigned            allows self-signed certificates

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ Options:
       --openssl path          path of the openssl binary to be used
    -p,--port port             TCP port
    -P,--protocol protocol     use the specific protocol
-                              {http|smtp|pop3|imap|imaps|ftp|xmpp|irc|ldap}
+                              {http|smtp|pop3|pop3s|imap|imaps|ftp|xmpp|irc|ldap}
                               http:                    default
-                              smtp,pop3,imap,ftp,ldap: switch to TLS
+                              smtp,pop3,imap,imaps,ftp,ldap: switch to TLS
    -s,--selfsigned            allows self-signed certificates
       --serial serialnum      pattern to match the serial number
       --sni name              sets the TLS SNI (Server Name Indication) extension

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -102,7 +102,7 @@ usage() {
     echo "      --openssl path          path of the openssl binary to be used"
     echo "   -p,--port port             TCP port"
     echo "   -P,--protocol protocol     use the specific protocol"
-    echo "                              {http|smtp|pop3|imap|imaps|ftp|xmpp|irc|ldap}"
+    echo "                              {http|smtp|pop3|pops3s|imap|imaps|ftp|xmpp|irc|ldap}"
     echo "                              http:                    default"
     echo "                              smtp,pop3,imap,ftp,ldap: switch to TLS"
     echo "   -s,--selfsigned            allows self-signed certificates"

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -104,7 +104,7 @@ usage() {
     echo "   -P,--protocol protocol     use the specific protocol"
     echo "                              {http|smtp|pop3|imap|imaps|ftp|xmpp|irc|ldap}"
     echo "                              http:                    default"
-    echo "                              smtp,pop3,imap,imaps,ftp,ldap: switch to TLS"
+    echo "                              smtp,pop3,imap,ftp,ldap: switch to TLS"
     echo "   -s,--selfsigned            allows self-signed certificates"
     echo "      --serial serialnum      pattern to match the serial number"
     echo "      --sni name              sets the TLS SNI (Server Name Indication) extension"
@@ -428,7 +428,7 @@ fetch_certificate() {
                 exec_with_timeout "$TIMEOUT" "echo 'Q' | $OPENSSL s_client ${CLIENT} ${CLIENTPASS} -starttls ${PROTOCOL} -connect $HOST:$PORT ${SERVERNAME} -verify 6 ${ROOT_CA} ${SSL_VERSION} ${SSL_VERSION_DISABLED} ${SSL_AU} 2> ${ERROR} 1> ${CERT}"
                 RET=$?
                 ;;
-            imaps)
+            pop3s|imaps)
                 exec_with_timeout "$TIMEOUT" "echo 'Q' | $OPENSSL s_client ${CLIENT} ${CLIENTPASS} -connect $HOST:$PORT ${SERVERNAME} -verify 6 ${ROOT_CA} ${SSL_VERSION} ${SSL_VERSION_DISABLED} ${SSL_AU} 2> ${ERROR} 1> ${CERT}"
                 RET=$?
                 ;;

--- a/check_ssl_cert.1
+++ b/check_ssl_cert.1
@@ -122,7 +122,7 @@ path of the openssl binary to be used
 TCP port
 .TP
 .BR "-P,--protocol" " protocol"
-use the specific protocol: http (default), irc or smtp,pop3,imap,imaps, ftp,ldap (switch to TLS)
+use the specific protocol: http (default), irc or smtp,pop3,imap,ftp,ldap (switch to TLS)
 .TP
 .BR "-s,--selfsigned"
 allows self-signed certificates

--- a/test/unit_tests.sh
+++ b/test/unit_tests.sh
@@ -221,6 +221,17 @@ testIMAPS() {
     fi	
 }
 
+testPOP3S() {
+    if [ -z "${TRAVIS+x}" ] ; then
+	${SCRIPT} --rootcert cabundle.crt -H pop.gmail.com --port 993 --timeout 30 --protocol pop3s
+	EXIT_CODE=$?
+	assertEquals "wrong exit code" "${NAGIOS_OK}" "${EXIT_CODE}"
+    else
+	echo "Skipping POP3S tests on Travis CI"
+    fi
+}
+
+
 testSMTP() {
     if [ -z "${TRAVIS+x}" ] ; then
 	${SCRIPT} --rootcert cabundle.crt -H smtp.gmail.com --protocol smtp --port 25 --timeout 60


### PR DESCRIPTION
Well, since IMAPS was added with #109 I might as well try to sneak in POP3S, POP3 over SSL/TLS.

Since introducing protocol variants that do not use STARTTLS but are directly connecting with TLS, what about having a distinction in the help message and manpage that makes a distinction?

For example
```
-    echo "                              smtp,pop3,imap,ftp,ldap: switch to TLS"
+    echo "                              smtp,pop3,imap,ftp,ldap: switch to TLS using STARTTLS"
+    echo "                              pop3s,imaps: <Protocol> over TLS"
```


Regards
Mathieu