### PR TITLE
handle -N and --cn together

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -1000,10 +1000,11 @@ main() {
     done
 
     ################################################################################
-    # Set COMMON_NAME to hostname if -N was given as argument
-    if [ "$COMMON_NAME" = "__HOST__" ] ; then
-        COMMON_NAME="${HOST}"
-    fi
+    # Set COMMON_NAME to hostname if -N was given as argument.
+    # COMMON_NAME may be a space separated list of hostnames.
+    case $COMMON_NAME in
+        *__HOST__*) COMMON_NAME=$(echo "$COMMON_NAME" | sed "s/__HOST__/${HOST}/") ;;
+    esac
 
     ################################################################################
     # Sanity checks


### PR DESCRIPTION
With arguments -N --cn "example.com", COMMON_NAME becaume "__HOST__ example.com".
This does not match "__HOST__" exactly, so the substitution was not done.

We use sed to do the substitution since ${var//} is a bash-ism.