### PR TITLE
In debug mode storing retrieved cert and OpenSSL errors into the TMPD…

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -586,11 +586,11 @@ fetch_certificate() {
     fi
 
     if [ -n "${DEBUG}" ] ; then
-        echo "[DBG] storing a copy of the retrieved certificate in ${HOST}.crt"
-        cp "${CERT}" "${HOST}.crt"
+        echo "[DBG] storing a copy of the retrieved certificate in ${TMPDIR}/${HOST}-${PORT}.crt"
+        cp "${CERT}" "${TMPDIR}/${HOST}-${PORT}.crt"
 
-        echo "[DBG] storing a copy of the OpenSSL errors in ${HOST}.error"
-        cp "${ERROR}" "${HOST}.error"
+        echo "[DBG] storing a copy of the OpenSSL errors in ${TMPDIR}/${HOST}-${PORT}.error"
+        cp "${ERROR}" "${TMPDIR}/${HOST}-${PORT}.error"
 
     fi
 


### PR DESCRIPTION
…IR and append the port to it.

The user running check_ssl_cert does not always have access permissions to write to the folder where check_ssl_cert is located causing the following error thrown in debug mode:

```
[DBG] storing a copy of the retrieved certificate in example.com.crt
cp: cannot create regular file 'example.com.crt': Permission denied
[DBG] storing a copy of the OpenSSL errors in example.com.error
cp: cannot create regular file 'example.com.error': Permission denied
```

In addition i have included the port in the filename as well because on multiple ports on the same host one file (maybe with an error on port 389) gets overwritten by an file without an error.

The result / output is the following:

```
[DBG] storing a copy of the retrieved certificate in /tmp/example.com-389.crt
[DBG] storing a copy of the OpenSSL errors in /tmp/example.com-389.error
```

and both files are correctly created.