### PR TITLE
Add SMTPS support

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -549,8 +549,7 @@ fetch_certificate() {
                 RET=$?
                 ;;
             smtps)
-                exec_with_timeout "${TIMEOUT}" "printf 'QUIT\\r' | ${OPENSSL} s_client ${INETPROTO} ${CLIENT} ${CLIENTPASS} -connect ${HOST}:${PORT} ${SERVERNAME} -verify 6 ${ROOT_CA} ${SSL_VERSION} ${SSL_VERSIO
-N_DISABLED} ${SSL_AU} 2> ${ERROR} 1> ${CERT}"
+                exec_with_timeout "${TIMEOUT}" "printf 'QUIT\\r' | ${OPENSSL} s_client ${INETPROTO} ${CLIENT} ${CLIENTPASS} -connect ${HOST}:${PORT} ${SERVERNAME} -verify 6 ${ROOT_CA} ${SSL_VERSION} ${SSL_VERSION_DISABLED} ${SSL_AU} 2> ${ERROR} 1> ${CERT}"
                 RET=$?
                 ;;
             irc)

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -113,7 +113,7 @@ usage() {
     echo "      --openssl path               path of the openssl binary to be used"
     echo "   -p,--port port                  TCP port"
     echo "   -P,--protocol protocol          use the specific protocol"
-    echo "                                   {ftp|http|imap|imaps|irc|ldap|ldaps|pop3|pop3s|smtp|xmpp}"
+    echo "                                   {ftp|http|imap|imaps|irc|ldap|ldaps|pop3|pop3s|smtp|smtps|xmpp}"
     echo "                                   http:                    default"
     echo "                                   ftp,imap,ldap,pop3,smtp: switch to TLS using StartTLS"
     echo "   -s,--selfsigned                 allows self-signed certificates"
@@ -546,6 +546,11 @@ fetch_certificate() {
         case "${PROTOCOL}" in
             smtp)
                 exec_with_timeout "${TIMEOUT}" "printf 'QUIT\\r' | ${OPENSSL} s_client ${INETPROTO} ${CLIENT} ${CLIENTPASS} -starttls ${PROTOCOL} -connect ${HOST}:${PORT} ${SERVERNAME} -verify 6 ${ROOT_CA} ${SSL_VERSION} ${SSL_VERSION_DISABLED} ${SSL_AU} 2> ${ERROR} 1> ${CERT}"
+                RET=$?
+                ;;
+            smtps)
+                exec_with_timeout "${TIMEOUT}" "printf 'QUIT\\r' | ${OPENSSL} s_client ${INETPROTO} ${CLIENT} ${CLIENTPASS} -connect ${HOST}:${PORT} ${SERVERNAME} -verify 6 ${ROOT_CA} ${SSL_VERSION} ${SSL_VERSIO
+N_DISABLED} ${SSL_AU} 2> ${ERROR} 1> ${CERT}"
                 RET=$?
                 ;;
             irc)

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -548,11 +548,7 @@ fetch_certificate() {
                 exec_with_timeout "${TIMEOUT}" "printf 'QUIT\\r' | ${OPENSSL} s_client ${INETPROTO} ${CLIENT} ${CLIENTPASS} -starttls ${PROTOCOL} -connect ${HOST}:${PORT} ${SERVERNAME} -verify 6 ${ROOT_CA} ${SSL_VERSION} ${SSL_VERSION_DISABLED} ${SSL_AU} 2> ${ERROR} 1> ${CERT}"
                 RET=$?
                 ;;
-            smtps)
-                exec_with_timeout "${TIMEOUT}" "printf 'QUIT\\r' | ${OPENSSL} s_client ${INETPROTO} ${CLIENT} ${CLIENTPASS} -connect ${HOST}:${PORT} ${SERVERNAME} -verify 6 ${ROOT_CA} ${SSL_VERSION} ${SSL_VERSION_DISABLED} ${SSL_AU} 2> ${ERROR} 1> ${CERT}"
-                RET=$?
-                ;;
-            irc)
+            irc|smtps)
                 exec_with_timeout "${TIMEOUT}" "printf 'QUIT\\r' | ${OPENSSL} s_client ${INETPROTO} ${CLIENT} ${CLIENTPASS} -connect ${HOST}:${PORT} ${SERVERNAME} -verify 6 ${ROOT_CA} ${SSL_VERSION} ${SSL_VERSION_DISABLED} ${SSL_AU} 2> ${ERROR} 1> ${CERT}"
                 RET=$?
                 ;;

--- a/check_ssl_cert.1
+++ b/check_ssl_cert.1
@@ -128,7 +128,7 @@ path of the openssl binary to be used
 TCP port
 .TP
 .BR "-P,--protocol" " protocol"
-use the specific protocol: ftp, http (default), imap, imaps, irc, ldap, ldaps, pop3, pop3s, smtp, xmpp.
+use the specific protocol: ftp, http (default), imap, imaps, irc, ldap, ldaps, pop3, pop3s, smtp, smtps, xmpp.
 .br
 These protocols switch to TLS using StartTLS: ftp, imap, ldap, pop3, smtp.
 .TP


### PR DESCRIPTION
While SMTPS on 465 isn't that recommended these days it's still widely used:

https://censys.io/ipv4?q=protocols%3A+%22465%2Fsmtp%22&