### PR TITLE
Mention the -d -v parameters in bug_report template. Add newlines.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,19 +7,19 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+**Describe the bug**\
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+**To Reproduce**\
 Steps to reproduce the behavior.
 
-**Expected behavior**
+**Expected behavior**\
 A clear and concise description of what you expected to happen.
 
-**System (please complete the following information):**
+**System (please complete the following information):**\
  - OS: [e.g. iOS]
  - OS Version: [e.g. 22]
  - check_ssl_cert Version: [e.g. 1.19.0]
 
-**Additional context**
-Add any other context about the problem here.
+**Additional context/output**\
+Add any other context or output (e.g. from `check_ssl_cert -d -v`) about the problem here.


### PR DESCRIPTION
This could help which info should be provided when facing a bug.