### PR TITLE
Validate OCSP stapling expiring

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,7 +65,7 @@ Thanks:
 * Many thanks to Łukasz Wąsikowski (https://github.com/IdahoPL) for the curl and date display patches
 * Many thanks to booboo-at-gluga-de (https://github.com/booboo-at-gluga-de) for the CRL patch
 * Many thanks to Georg (https://github.com/gbotti) for the fingerprint patch
-* Many thanks to Wim van Ravesteijn (https://github.com/wimvr) for the DER encoded CRL files patch
+* Many thanks to Wim van Ravesteijn (https://github.com/wimvr) for the DER encoded CRL files patch and the OCSP expiring date patch
 * Many thanks to yasirathackersdotmu (https://github.com/yasirathackersdotmu)
 * Many thanks to Christoph Moench-Tegeder (https://github.com/moench-tegeder) for the curl patch
 * Many thanks to Dan Pritts for the --terse patch

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,4 @@
+Validate OCSP stapling expiring date
 2019-09-25 Version 1.96.0: Bug fixes
 2019-09-24 Version 1.95.0: Bug fixes
 2019-09-24 Version 1.94.0: Several bugs fixed

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -1806,16 +1806,16 @@ main() {
             if [ -n "${VERBOSE}" ] ; then
                 echo "  OCSP stapling enabled"
             fi
-            NEXT_UPDATE=`grep -Po 'Next Update: .*$' ${OCSP_RESPONSE_TMP} | cut -b14-`
-            OCSP_EXPIRES_AT=`date -d "${NEXT_UPDATE}" +%s`
-            NOW=`date +%s`
+            NEXT_UPDATE=$(grep -Po 'Next Update: .*$' "${OCSP_RESPONSE_TMP}" | cut -b14-)
+            OCSP_EXPIRES_AT=$(date -d "${NEXT_UPDATE}" +%s)
+            NOW=$(date +%s)
             OCSP_EXPIRES_IN_HOURS=$(( (OCSP_EXPIRES_AT - NOW) / 3600 ))
             if [ -n "${VERBOSE}" ] ; then
                 echo "  OCSP stapling expires in ${OCSP_EXPIRES_IN_HOURS} hours"
             fi
-            if [ -n "${OCSP_CRITICAL}" ] && [ ${OCSP_CRITICAL} -ge ${OCSP_EXPIRES_IN_HOURS} ] ; then
+            if [ -n "${OCSP_CRITICAL}" ] && [ "${OCSP_CRITICAL}" -ge "${OCSP_EXPIRES_IN_HOURS}" ] ; then
                 prepend_critical_message "${OPENSSL_COMMAND} OCSP stapling will expire in ${OCSP_EXPIRES_IN_HOURS} hour(s) on ${NEXT_UPDATE}"
-            elif [ -n "${OCSP_WARNING}" ] && [ ${OCSP_WARNING} -ge ${OCSP_EXPIRES_IN_HOURS} ] ; then
+            elif [ -n "${OCSP_WARNING}" ] && [ "${OCSP_WARNING}" -ge "${OCSP_EXPIRES_IN_HOURS}" ] ; then
                 append_warning_message "${OPENSSL_COMMAND} OCSP stapling will expire in ${OCSP_EXPIRES_IN_HOURS} hour(s) on ${NEXT_UPDATE}"
             fi
         fi

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -222,11 +222,11 @@ create_temporary_file() {
 }
 
 ################################################################################
-# Compute the number of days until a given date
+# Compute the number of hours until a given date
 # Params
 #   $1 date
-# Sets DAYS_UNTIL
-days_until() {
+# Sets HOURS_UNTIL
+hours_until() {
 
     DATE=$1
     
@@ -235,27 +235,27 @@ days_until() {
 
     if [ -n "${DEBUG}" ] ; then
         echo "[DBG] Date computations: ${DATETYPE}"
-	echo "[DBG] Computing number of days until ${DATE}"
+	echo "[DBG] Computing number of hours until '${DATE}'"
     fi
 
     case "${DATETYPE}" in
         "BSD")
-            DAYS_UNTIL=$(( ( $(${DATEBIN} -jf "%b %d %T %Y %Z" "${DATE}" +%s) - $(${DATEBIN} +%s) ) / 86400 ))
+            HOURS_UNTIL=$(( ( $(${DATEBIN} -jf "%b %d %T %Y %Z" "${DATE}" +%s) - $(${DATEBIN} +%s) ) / 3600 ))
             ;;
 	
         "GNU")
-            DAYS_UNTIL=$(( ( $(${DATEBIN} -d "${DATE}" +%s) - $(${DATEBIN} +%s) ) / 86400 ))
+            HOURS_UNTIL=$(( ( $(${DATEBIN} -d "${DATE}" +%s) - $(${DATEBIN} +%s) ) / 3600 ))
             ;;
 
         "PERL")
             # Warning: some shell script formatting tools will indent the EOF! (should be at position 0)
-            if ! DAYS_UNTIL=$(perl - "${DATE}" <<-"EOF"
+            if ! HOURS_UNTIL=$(perl - "${DATE}" <<-"EOF"
                     use strict;
                     use warnings;
                     use Date::Parse;
                     my $cert_date = str2time( $ARGV[0] );
-                    my $days = int (( $cert_date - time ) / 86400 + 0.5);
-                    print "$days\n";
+                    my $hours = int (( $cert_date - time ) / 3600 + 0.5);
+                    print "$hours\n";
 EOF
                  ) ; then
                 # something went wrong with the embedded Perl code: check the indentation of EOF
@@ -269,7 +269,7 @@ EOF
     LANG="${OLDLANG}"
 
     if [ -n "${DEBUG}" ] ; then
-	echo "[DBG] Days until ${DATE}: ${DAYS_UNTIL}"
+	echo "[DBG] Hours until ${DATE}: ${HOURS_UNTIL}"
     fi    
 
 }
@@ -1861,9 +1861,9 @@ main() {
             fi
             NEXT_UPDATE=$(grep -o 'Next Update: .*$' "${OCSP_RESPONSE_TMP}" | cut -b14-)
 
-	    days_until "${NEXT_UPDATE}"
+	    hours_until "${NEXT_UPDATE}"
 	    
-            OCSP_EXPIRES_IN_HOURS=$(( DAYS_UNTIL / 3600 ))
+            OCSP_EXPIRES_IN_HOURS="${HOURS_UNTIL}"
             if [ -n "${VERBOSE}" ] ; then
                 echo "  OCSP stapling expires in ${OCSP_EXPIRES_IN_HOURS} hours"
             fi
@@ -1961,8 +1961,8 @@ main() {
     # shellcheck disable=SC2086
         CERT_END_DATE=$("${OPENSSL}" "${OPENSSL_COMMAND}" ${OPENSSL_PARAMS} -in "${CERT}" -noout "${OPENSSL_ENDDATE_OPTION}" | sed -e "s/.*=//")
 
-	days_until "${CERT_END_DATE}"
-	DAYS_VALID="${DAYS_UNTIL}"
+	hours_until "${CERT_END_DATE}"
+	DAYS_VALID=$(( HOURS_UNTIL / 24 ))
 	
         if [ -n "${VERBOSE}" ] ; then
 

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -1806,7 +1806,7 @@ main() {
             if [ -n "${VERBOSE}" ] ; then
                 echo "  OCSP stapling enabled"
             fi
-            NEXT_UPDATE=$(grep -Po 'Next Update: .*$' "${OCSP_RESPONSE_TMP}" | cut -b14-)
+            NEXT_UPDATE=$(grep -o 'Next Update: .*$' "${OCSP_RESPONSE_TMP}" | cut -b14-)
             OCSP_EXPIRES_AT=$(date -d "${NEXT_UPDATE}" +%s)
             NOW=$(date +%s)
             OCSP_EXPIRES_IN_HOURS=$(( (OCSP_EXPIRES_AT - NOW) / 3600 ))

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -111,6 +111,10 @@ usage() {
     echo "      --no_tls1_1                  disable TLS version 1.1"
     echo "      --no_tls1_2                  disable TLS version 1.2"
     echo "   -N,--host-cn                    match CN with the host name"
+    echo "      --ocsp-critical hours        minimum number of hours an OCSP response has to be valid to"
+    echo "                                   issue a critical status"
+    echo "      --ocsp-warning hours         minimum number of hours an OCSP response has to be valid to"
+    echo "                                   issue a warning status"
     echo "   -o,--org org                    pattern to match the organization of the certificate"
     echo "      --openssl path               path of the openssl binary to be used"
     echo "   -p,--port port                  TCP port"
@@ -998,6 +1002,22 @@ main() {
                     unknown "-n,--cn requires an argument"
                 fi
                 ;;
+            --ocsp-critical)
+                if [ $# -gt 1 ]; then
+                    OCSP_CRITICAL="$2"
+                    shift 2
+                else
+                    unknown "--ocsp-critical requires an argument"
+                fi
+                ;;
+            --ocsp-warning)
+                if [ $# -gt 1 ]; then
+                    OCSP_WARNING="$2"
+                    shift 2
+                else
+                    unknown "--ocsp-warning requires an argument"
+                fi
+                ;;
             -o|--org)
                 if [ $# -gt 1 ]; then
                     ORGANIZATION="$2"
@@ -1785,6 +1805,18 @@ main() {
         else
             if [ -n "${VERBOSE}" ] ; then
                 echo "  OCSP stapling enabled"
+            fi
+            NEXT_UPDATE=`grep -Po 'Next Update: .*$' ${OCSP_RESPONSE_TMP} | cut -b14-`
+            OCSP_EXPIRES_AT=`date -d "${NEXT_UPDATE}" +%s`
+            NOW=`date +%s`
+            OCSP_EXPIRES_IN=$(( (OCSP_EXPIRES_AT - NOW) / 3600 ))
+            if [ -n "${VERBOSE}" ] ; then
+                echo "  OCSP stapling expires in ${OCSP_EXPIRES_IN} hours"
+            fi
+            if [ -n "${OCSP_CRITICAL}" ] && [ ${OCSP_CRITICAL} -ge ${OCSP_EXPIRES_IN} ] ; then
+                prepend_critical_message "${OPENSSL_COMMAND} OCSP stapling will expire in ${OCSP_EXPIRES_IN} hour(s) on ${NEXT_UPDATE}"
+            elif [ -n "${OCSP_WARNING}" ] && [ ${OCSP_WARNING} -ge ${OCSP_EXPIRES_IN} ] ; then
+                append_warning_message "${OPENSSL_COMMAND} OCSP stapling will expire in ${OCSP_EXPIRES_IN} hour(s) on ${NEXT_UPDATE}"
             fi
         fi
 

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -1809,14 +1809,14 @@ main() {
             NEXT_UPDATE=`grep -Po 'Next Update: .*$' ${OCSP_RESPONSE_TMP} | cut -b14-`
             OCSP_EXPIRES_AT=`date -d "${NEXT_UPDATE}" +%s`
             NOW=`date +%s`
-            OCSP_EXPIRES_IN=$(( (OCSP_EXPIRES_AT - NOW) / 3600 ))
+            OCSP_EXPIRES_IN_HOURS=$(( (OCSP_EXPIRES_AT - NOW) / 3600 ))
             if [ -n "${VERBOSE}" ] ; then
-                echo "  OCSP stapling expires in ${OCSP_EXPIRES_IN} hours"
+                echo "  OCSP stapling expires in ${OCSP_EXPIRES_IN_HOURS} hours"
             fi
-            if [ -n "${OCSP_CRITICAL}" ] && [ ${OCSP_CRITICAL} -ge ${OCSP_EXPIRES_IN} ] ; then
-                prepend_critical_message "${OPENSSL_COMMAND} OCSP stapling will expire in ${OCSP_EXPIRES_IN} hour(s) on ${NEXT_UPDATE}"
-            elif [ -n "${OCSP_WARNING}" ] && [ ${OCSP_WARNING} -ge ${OCSP_EXPIRES_IN} ] ; then
-                append_warning_message "${OPENSSL_COMMAND} OCSP stapling will expire in ${OCSP_EXPIRES_IN} hour(s) on ${NEXT_UPDATE}"
+            if [ -n "${OCSP_CRITICAL}" ] && [ ${OCSP_CRITICAL} -ge ${OCSP_EXPIRES_IN_HOURS} ] ; then
+                prepend_critical_message "${OPENSSL_COMMAND} OCSP stapling will expire in ${OCSP_EXPIRES_IN_HOURS} hour(s) on ${NEXT_UPDATE}"
+            elif [ -n "${OCSP_WARNING}" ] && [ ${OCSP_WARNING} -ge ${OCSP_EXPIRES_IN_HOURS} ] ; then
+                append_warning_message "${OPENSSL_COMMAND} OCSP stapling will expire in ${OCSP_EXPIRES_IN_HOURS} hour(s) on ${NEXT_UPDATE}"
             fi
         fi
 
@@ -2730,6 +2730,21 @@ EOF
         fi
     fi
 
+    if [ -n "${OCSP_EXPIRES_IN_HOURS}" ] ; then
+        # nicer formatting
+        if [ "${OCSP_EXPIRES_IN_HOURS}" -gt 1 ] ; then
+            OCSP_EXPIRES_IN_HOURS=" (OCSP stapling expires in ${OCSP_EXPIRES_IN_HOURS} hours)"
+        elif [ "${OCSP_EXPIRES_IN_HOURS}" -eq 1 ] ; then
+            OCSP_EXPIRES_IN_HOURS=" (OCSP stapling expires in one hour)"
+        elif [ "${OCSP_EXPIRES_IN_HOURS}" -eq 0 ] ; then
+            OCSP_EXPIRES_IN_HOURS=" (OCSP stapling expires now)"
+        elif [ "${OCSP_EXPIRES_IN_HOURS}" -eq -1 ] ; then
+            OCSP_EXPIRES_IN_HOURS=" (OCSP stapling expired one hour ago)"
+        else
+            OCSP_EXPIRES_IN_HOURS=" (OCSP stapling expired ${OCSP_EXPIRES_IN_HOURS} hours ago)"
+        fi
+    fi
+
     if [ -n "${SSL_LABS_HOST_GRADE}" ] ; then
         SSL_LABS_HOST_GRADE=", SSL Labs grade: ${SSL_LABS_HOST_GRADE}"
     fi
@@ -2744,7 +2759,7 @@ EOF
         if [ -n "${TERSE}" ]; then
             FORMAT="%SHORTNAME% OK %CN% %DAYS_VALID%"
         else
-            FORMAT="%SHORTNAME% OK - %OPENSSL_COMMAND% %SELFSIGNEDCERT%certificate %DISPLAY_CN%%CHECKEDNAMES%from '%CA_ISSUER_MATCHED%' valid until %DATE%%DAYS_VALID%%SSL_LABS_HOST_GRADE%"
+            FORMAT="%SHORTNAME% OK - %OPENSSL_COMMAND% %SELFSIGNEDCERT%certificate %DISPLAY_CN%%CHECKEDNAMES%from '%CA_ISSUER_MATCHED%' valid until %DATE%%DAYS_VALID%%OCSP_EXPIRES_IN_HOURS%%SSL_LABS_HOST_GRADE%"
         fi
     fi
 
@@ -2755,16 +2770,17 @@ EOF
     fi
 
     if [ -n "${DEBUG}" ] ; then
-        echo "[DBG] output parameters: CA_ISSUER_MATCHED   = ${CA_ISSUER_MATCHED}"
-        echo "[DBG] output parameters: CHECKEDNAMES        = ${CHECKEDNAMES}"
-        echo "[DBG] output parameters: CN                  = ${CN}"
-        echo "[DBG] output parameters: DATE                = ${DATE}"
-        echo "[DBG] output parameters: DAYS_VALID          = ${DAYS_VALID}"
-        echo "[DBG] output parameters: DYSPLAY_CN          = ${DISPLAY_CN}"
-        echo "[DBG] output parameters: OPENSSL_COMMAND     = ${OPENSSL_COMMAND}"
-        echo "[DBG] output parameters: SELFSIGNEDCERT      = ${SELFSIGNEDCERT}"
-        echo "[DBG] output parameters: SHORTNAME           = ${SHORTNAME}"
-        echo "[DBG] output parameters: SSL_LABS_HOST_GRADE = ${SSL_LABS_HOST_GRADE}"
+        echo "[DBG] output parameters: CA_ISSUER_MATCHED     = ${CA_ISSUER_MATCHED}"
+        echo "[DBG] output parameters: CHECKEDNAMES          = ${CHECKEDNAMES}"
+        echo "[DBG] output parameters: CN                    = ${CN}"
+        echo "[DBG] output parameters: DATE                  = ${DATE}"
+        echo "[DBG] output parameters: DAYS_VALID            = ${DAYS_VALID}"
+        echo "[DBG] output parameters: DYSPLAY_CN            = ${DISPLAY_CN}"
+        echo "[DBG] output parameters: OPENSSL_COMMAND       = ${OPENSSL_COMMAND}"
+        echo "[DBG] output parameters: SELFSIGNEDCERT        = ${SELFSIGNEDCERT}"
+        echo "[DBG] output parameters: SHORTNAME             = ${SHORTNAME}"
+        echo "[DBG] output parameters: OCSP_EXPIRES_IN_HOURS = ${OCSP_EXPIRES_IN_HOURS}"
+        echo "[DBG] output parameters: SSL_LABS_HOST_GRADE   = ${SSL_LABS_HOST_GRADE}"
     fi
 
     echo "${FORMAT}${EXTRA_OUTPUT}" | sed \
@@ -2777,6 +2793,7 @@ EOF
         -e "$( var_for_sed OPENSSL_COMMAND "${OPENSSL_COMMAND}" )" \
         -e "$( var_for_sed SELFSIGNEDCERT "${SELFSIGNEDCERT}" )" \
         -e "$( var_for_sed SHORTNAME "${SHORTNAME}" )" \
+        -e "$( var_for_sed OCSP_EXPIRES_IN_HOURS "${OCSP_EXPIRES_IN_HOURS}" )" \
         -e "$( var_for_sed SSL_LABS_HOST_GRADE "${SSL_LABS_HOST_GRADE}" )"
 
     remove_temporary_files

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -222,6 +222,59 @@ create_temporary_file() {
 }
 
 ################################################################################
+# Compute the number of days until a given date
+# Params
+#   $1 date
+# Sets DAYS_UNTIL
+days_until() {
+
+    DATE=$1
+    
+    OLDLANG="${LANG}"
+    LANG=en_US
+
+    if [ -n "${DEBUG}" ] ; then
+        echo "[DBG] Date computations: ${DATETYPE}"
+	echo "[DBG] Computing number of days until ${DATE}"
+    fi
+
+    case "${DATETYPE}" in
+        "BSD")
+            DAYS_UNTIL=$(( ( $(${DATEBIN} -jf "%b %d %T %Y %Z" "${DATE}" +%s) - $(${DATEBIN} +%s) ) / 86400 ))
+            ;;
+	
+        "GNU")
+            DAYS_UNTIL=$(( ( $(${DATEBIN} -d "${DATE}" +%s) - $(${DATEBIN} +%s) ) / 86400 ))
+            ;;
+
+        "PERL")
+            # Warning: some shell script formatting tools will indent the EOF! (should be at position 0)
+            if ! DAYS_UNTIL=$(perl - "${DATE}" <<-"EOF"
+                    use strict;
+                    use warnings;
+                    use Date::Parse;
+                    my $cert_date = str2time( $ARGV[0] );
+                    my $days = int (( $cert_date - time ) / 86400 + 0.5);
+                    print "$days\n";
+EOF
+                 ) ; then
+                # something went wrong with the embedded Perl code: check the indentation of EOF
+                unknown "Error computing the certificate validity with Perl"
+            fi
+            ;;
+	*)
+	    unknown "Internal error: unknown date type"
+    esac
+
+    LANG="${OLDLANG}"
+
+    if [ -n "${DEBUG}" ] ; then
+	echo "[DBG] Days until ${DATE}: ${DAYS_UNTIL}"
+    fi    
+
+}
+
+################################################################################
 # prepends critical messages to list of all messages
 # Params
 #   $1 error message
@@ -1807,9 +1860,10 @@ main() {
                 echo "  OCSP stapling enabled"
             fi
             NEXT_UPDATE=$(grep -o 'Next Update: .*$' "${OCSP_RESPONSE_TMP}" | cut -b14-)
-            OCSP_EXPIRES_AT=$(date -d "${NEXT_UPDATE}" +%s)
-            NOW=$(date +%s)
-            OCSP_EXPIRES_IN_HOURS=$(( (OCSP_EXPIRES_AT - NOW) / 3600 ))
+
+	    days_until "${NEXT_UPDATE}"
+	    
+            OCSP_EXPIRES_IN_HOURS=$(( DAYS_UNTIL / 3600 ))
             if [ -n "${VERBOSE}" ] ; then
                 echo "  OCSP stapling expires in ${OCSP_EXPIRES_IN_HOURS} hours"
             fi
@@ -1907,43 +1961,9 @@ main() {
     # shellcheck disable=SC2086
         CERT_END_DATE=$("${OPENSSL}" "${OPENSSL_COMMAND}" ${OPENSSL_PARAMS} -in "${CERT}" -noout "${OPENSSL_ENDDATE_OPTION}" | sed -e "s/.*=//")
 
-        OLDLANG="${LANG}"
-        LANG=en_US
-
-        if [ -n "${DEBUG}" ] ; then
-            echo "[DBG] Date computations: ${DATETYPE}"
-        fi
-
-        case "${DATETYPE}" in
-            "BSD")
-                DAYS_VALID=$(( ( $(${DATEBIN} -jf "%b %d %T %Y %Z" "${CERT_END_DATE}" +%s) - $(${DATEBIN} +%s) ) / 86400 ))
-                ;;
-
-            "GNU")
-                DAYS_VALID=$(( ( $(${DATEBIN} -d "${CERT_END_DATE}" +%s) - $(${DATEBIN} +%s) ) / 86400 ))
-                ;;
-
-            "PERL")
-                # Warning: some shell script formatting tools will indent the EOF! (should be at position 0)
-                if ! DAYS_VALID=$(perl - "${CERT_END_DATE}" <<-"EOF"
-                    use strict;
-                    use warnings;
-                    use Date::Parse;
-                    my $cert_date = str2time( $ARGV[0] );
-                    my $days = int (( $cert_date - time ) / 86400 + 0.5);
-                    print "$days\n";
-EOF
-                ) ; then
-                    # something went wrong with the embedded Perl code: check the indentation of EOF
-                    unknown "Error computing the certificate validity with Perl"
-                fi
-                ;;
-      *)
-    unknown "Internal error: unknown date type"
-        esac
-
-        LANG="${OLDLANG}"
-
+	days_until "${CERT_END_DATE}"
+	DAYS_VALID="${DAYS_UNTIL}"
+	
         if [ -n "${VERBOSE}" ] ; then
 
             if [ "${DAYS_VALID}" -ge 0 ] ; then

--- a/test/unit_tests.sh
+++ b/test/unit_tests.sh
@@ -30,6 +30,27 @@ NAGIOS_WARNING=1
 NAGIOS_CRITICAL=2
 NAGIOS_UNKNOWN=3
 
+testHoursUntilNow() {
+    # testing with perl
+    export DATETYPE='PERL'
+    hours_until "$( date )"
+    assertEquals "error computing the missing hours until now" 0 "${HOURS_UNTIL}"
+}
+
+testHoursUntil5Hours() {
+    # testing with perl
+    export DATETYPE='PERL'
+    hours_until "$( perl -e '$x=localtime(time+(5*3600));print $x' )"
+    assertEquals "error computing the missing hours until now" 5 "${HOURS_UNTIL}"
+}
+
+testHoursUntil42Hours() {
+    # testing with perl
+    export DATETYPE='PERL'
+    hours_until "$( perl -e '$x=localtime(time+(42*3600));print $x' )"
+    assertEquals "error computing the missing hours until now" 42 "${HOURS_UNTIL}"
+}
+
 testDependencies() {
     check_required_prog openssl
     # $PROG is defined in the script
@@ -302,24 +323,6 @@ testBadSSLSHA256() {
 	echo "Skipping SHA 256 with badssl.com on Travis CI"
     fi
 }
-
-# exired on Feb 17 2019
-#testBadSSL1000SANs() {
-#    if [ -z "${TRAVIS+x}" ] ; then
-#	${SCRIPT} -H 1000-sans.badssl.com --host-cn
-#	EXIT_CODE=$?
-#	assertEquals "wrong exit code" "${NAGIOS_OK}" "${EXIT_CODE}"
-#    else
-#	echo "Skipping 1000 subject alternative names with badssl.com on Travis CI"
-#    fi
-#}
-
-# Disabled as OpenSSL does not seem to handle it
-#testBadSSL10000SANs() {
-#    ${SCRIPT} -H 10000-sans.badssl.com --host-cn
-#    EXIT_CODE=$?
-#    assertEquals "wrong exit code" "${NAGIOS_OK}" "${EXIT_CODE}"
-#}
 
 testBadSSLEcc256() {
     if [ -z "${TRAVIS+x}" ] ; then


### PR DESCRIPTION
Plugin currently only checks if an OCSP stapling response has a 'Next Update'. With this addition, it also checks the number of hours left till next update.