### PR TITLE
Add support for STARTTLS over Sieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Options:
       --openssl path               path of the openssl binary to be used
    -p,--port port                  TCP port
    -P,--protocol protocol          use the specific protocol
-                                   {ftp|ftps|http|imap|imaps|irc|ircs|ldap|ldaps|pop3|pop3s|smtp|smtps|xmpp}
+                                   {ftp|ftps|http|imap|imaps|irc|ircs|ldap|ldaps|pop3|pop3s|sieve|smtp|smtps|xmpp}
                                    http:                    default
                                    ftp,imap,irc,ldap,pop3,smtp: switch to TLS using StartTLS
    -s,--selfsigned                 allows self-signed certificates

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -126,9 +126,9 @@ usage() {
     echo "      --openssl path               path of the openssl binary to be used"
     echo "   -p,--port port                  TCP port"
     echo "   -P,--protocol protocol          use the specific protocol"
-    echo "                                   {ftp|ftps|http|imap|imaps|irc|ircs|ldap|ldaps|pop3|pop3s|smtp|smtps|xmpp}"
+    echo "                                   {ftp|ftps|http|imap|imaps|irc|ircs|ldap|ldaps|pop3|pop3s|sieve|smtp|smtps|xmpp}"
     echo "                                   http:                    default"
-    echo "                                   ftp,imap,irc,ldap,pop3,smtp: switch to TLS using StartTLS"
+    echo "                                   ftp,imap,irc,ldap,pop3,sieve,smtp: switch to TLS using StartTLS"
     echo "   -s,--selfsigned                 allows self-signed certificates"
     echo "      --serial serialnum           pattern to match the serial number"
     echo "      --sni name                   sets the TLS SNI (Server Name Indication) extension"
@@ -655,6 +655,10 @@ fetch_certificate() {
                 ;;
             imaps)
                 exec_with_timeout "${TIMEOUT}" "printf 'A01 LOGOUT\\n' | ${OPENSSL} s_client ${INETPROTO} ${CLIENT} ${CLIENTPASS} -crlf ${IGN_EOF} -connect ${HOST}:${PORT} ${SERVERNAME} -verify 6 ${ROOT_CA} ${SSL_VERSION} ${SSL_VERSION_DISABLED} ${SSL_AU} ${STATUS} ${DANE} 2> ${ERROR} 1> ${CERT}"
+                RET=$?
+                ;;
+            sieve)
+                exec_with_timeout "${TIMEOUT}" "echo 'LOGOUT' | ${OPENSSL} s_client ${INETPROTO} ${CLIENT} ${CLIENTPASS} -starttls ${PROTOCOL} -connect ${HOST}:${XMPPPORT} ${XMPPHOST} -verify 6 ${ROOT_CA} ${SSL_VERSION} ${SSL_VERSION_DISABLED} ${SSL_AU} ${STATUS} ${DANE} 2> ${ERROR} 1> ${CERT}"
                 RET=$?
                 ;;
             xmpp)

--- a/check_ssl_cert.1
+++ b/check_ssl_cert.1
@@ -158,7 +158,7 @@ path of the openssl binary to be used
 TCP port
 .TP
 .BR "-P,--protocol" " protocol"
-use the specific protocol: ftp, ftps, http (default), imap, imaps, irc, ircs, ldap, ldaps, pop3, pop3s, smtp, smtps, xmpp.
+use the specific protocol: ftp, ftps, http (default), imap, imaps, irc, ircs, ldap, ldaps, pop3, pop3s, sieve, smtp, smtps, xmpp.
 .br
 These protocols switch to TLS using StartTLS: ftp, imap, irc, ldap, pop3, smtp.
 .TP


### PR DESCRIPTION
Runs with openssl 1.1.1.  Does not work with openssl 1.1.0 or 1.0.2.

Closes: #178