### PR TITLE
Remove superfluous "xs" in echo output.

### DIFF
--- a/test/unit_tests.sh
+++ b/test/unit_tests.sh
@@ -20,7 +20,7 @@ fi
 
 SCRIPT=../check_ssl_cert
 if [ ! -r "${SCRIPT}" ] ; then
-    echo "Error: the script to test (${SCRIPT}) is not a readable file"xs
+    echo "Error: the script to test (${SCRIPT}) is not a readable file"
 fi
 
 oneTimeSetUp() {


### PR DESCRIPTION
Looks like this was accidentally introduced in cfb969a86943a3fcdd57ec08a59b6625ce24e6b7