### PR TITLE
Fix --issuer check to support both O and CN again

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -2198,9 +2198,9 @@ main() {
     # OpenSSL 1.1.0: issuer=C = XY, ST = Alpha, L = Bravo, O = Charlie, CN = Charlie SSL CA
     # OpenSSL 1.0.2: issuer= /C=XY/ST=Alpha/L=Bravo/O=Charlie/CN=Charlie SSL CA 3
     # shellcheck disable=SC2086
-    ISSUERS=$(echo "${ISSUERS}" | sed 's/\\n/\n/g' | sed -e "s/^.*\\/CN=//" -e "s/^.* CN = //" -e "s/^.*, O = //" -e "s/\\/[A-Za-z][A-Za-z]*=.*\$//" -e "s/, [A-Za-z][A-Za-z]* =.*\$//")
+    ISSUERS=$(echo "${ISSUERS}" | sed 's/\\n/\n/g' | sed -E -e "s/^issuer=( \/)?//" -e "s/\, |\//\\n/g" | grep -E "^(O|CN) ?= ?" | sed -E -e "s/^(O|CN) ?= ?//" )
 
-    debuglog '[DBG] ISSUERS = '
+    debuglog 'ISSUERS = '
     debuglog "    ${ISSUERS}"
 
     # we just consider the first URI


### PR DESCRIPTION
Fix --issuer check to support both O and CN again.
Also this version recover support of CN as a first token.

Issue: #206

Algo:

1) Strip `issuer=` prefix in both supported forms of OpenSSL output
2) Tokenize by 'comma-space' or 'backslash'
3) Select only required tokens (O and CN)
4) Remove O/CN prefix from tokens

This adds two additional calls: one 'sed' and one 'grep'.

This could be improved by deferring filtering, if it would be necessary to build 'invalid CA' message.
But this makes that 'ugly' line ever more ugly (IMHO), and a bit cosmetic change, so I leave that your discretion, patch below:

```
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -2198,7 +2198,7 @@ main() {
     # OpenSSL 1.1.0: issuer=C = XY, ST = Alpha, L = Bravo, O = Charlie, CN = Charlie SSL CA
     # OpenSSL 1.0.2: issuer= /C=XY/ST=Alpha/L=Bravo/O=Charlie/CN=Charlie SSL CA 3
     # shellcheck disable=SC2086
-    ISSUERS=$(echo "${ISSUERS}" | sed 's/\\n/\n/g' | sed -E  -e "s/^issuer=( \/)?//"  -e "s/\, |\//\\n/g"  | grep -E "^(O|CN)" | sed -E -e "s/^(O|CN) ?= ?//" )
+    ISSUERS=$(echo "${ISSUERS}" | sed 's/\\n/\n/g' | sed -E  -e "s/^issuer=( \/)?//" -e "s/\, |\//\\n/g")


     debuglog 'ISSUERS = '
@@ -2460,15 +2460,16 @@ main() {
         debuglog "check ISSUER: ${ISSUER}"

         ok=""
-        CA_ISSUER_MATCHED=$(echo "${ISSUERS}" | grep -E "^${ISSUER}\$" | head -n1)
+        CA_ISSUER_MATCHED=$(echo "${ISSUERS}" | grep -E "^(O|CN) ?= ?${ISSUER}\$" | head -n1)

         debuglog "   issuer matched = ${CA_ISSUER_MATCHED}"

         if [ -n "${CA_ISSUER_MATCHED}" ]; then
             ok="true"
         else
+            #| grep -E "^(O|CN)" | sed -E -e "s/^(O|CN) ?= ?//"
             # this looks ugly but preserves spaces in CA name
-            prepend_critical_message "invalid CA ('$(echo "${ISSUER}" | sed "s/|/ PIPE /g")' does not match '$(echo "${ISSUERS}" | tr '\n' '|' | sed "s/|\$//g" | sed "s/|/\\' or \\'/g")')"
+            prepend_critical_message "invalid CA ('$(echo "${ISSUER}" | sed "s/|/ PIPE /g")' does not match '$(echo "${ISSUERS}" | grep -E "^(O|CN) ?=" | tr '\n' '|' | sed "s/|\$//g" | sed "s/|/\\' or \\'/g")')"
         fi

     else
```

As a side effect, you can display the field name in an error message, if not apply `sed -E -e "s/^(O|CN) ?= ?//"`:

```
SSL_CERT CRITICAL *.domain.tld: invalid CA ('Alfa Software Root CA' does not match 'O = COMODO CA Limited' or 'CN = COMODO RSA Domain Validation Secure Server CA' or 'O = COMODO CA Limited' or 'CN = COMODO RSA Certification Authority')|days_chain_elem1=176;7;1;; days_chain_elem2=3167;7;1;;
```

You can also notice `O = COMODO CA Limited` included twice, but I think that is a bit hard to remove such duplicates.