### PR TITLE
fix: do not show file version by default

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -1697,7 +1697,7 @@ main() {
     check_required_prog "${FILE_BIN}"
     FILE_BIN=${PROG}
 
-    debuglog "file version: $( "${FILE_BIN}" --version )"
+    debuglog "file version: $( "${FILE_BIN}" --version 2>&1 )"
 
     # cURL
     if [ -z "${CURL_BIN}" ] ; then


### PR DESCRIPTION
Fixes #217 

## Proposed Changes

  - Redirect file output to stdout, which will be shown only when debug is enabled
