### PR TITLE
Remove unnecessary characters from HTML markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-1;95;0c<html lang="en-us">
+<html lang="en-us">
   <head>
     <meta charset="UTF-8">
     <title>check_ssl_cert by matteocorti</title>


### PR DESCRIPTION
## Proposed Changes
- Remove string `1;95;0c` from project's website https://matteocorti.github.io/check_ssl_cert/.

![Снимок экрана от 2020-11-10 11-37-07](https://user-images.githubusercontent.com/212711/98628421-2711e100-2349-11eb-9ce5-f01e2e092d88.png)
