### PR TITLE
Only consider HTTP(S) ISSUER URIs

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -2275,10 +2275,10 @@ main() {
     debuglog 'ISSUERS = '
     debuglog "${ISSUERS}"
 
-    # we just consider the first URI
+    # we just consider the first HTTP(S) URI
     # TODO check SC2016
     # shellcheck disable=SC2086,SC2016
-    ISSUER_URI="$(${OPENSSL} "${OPENSSL_COMMAND}" ${OPENSSL_PARAMS} -in "${CERT}" -text -noout | grep "CA Issuers" | head -n 1 | sed -e "s/^.*CA Issuers - URI://" | tr -d '"!|;$(){}<>`&')"
+    ISSUER_URI="$(${OPENSSL} "${OPENSSL_COMMAND}" ${OPENSSL_PARAMS} -in "${CERT}" -text -noout | grep "CA Issuers" | grep -i "http" | head -n 1 | sed -e "s/^.*CA Issuers - URI://" | tr -d '"!|;$(){}<>`&')"
 
     # TODO: should be checked
     # shellcheck disable=SC2021


### PR DESCRIPTION
I'm testing against a cert which has the following:
```
                CA Issuers - URI:ldap:///CN=bar,DC=foo,DC=example?cACertificate?base?objectClass=certificationAuthority
                CA Issuers - URI:http://foo.example/bar.crt
```

I don't know if this is against standards or whatever, but unmodified check_ssl_cert selects the LDAP URI and then chucks out the "unable to fetch the CA issuer certificate (unsupported protocol)" this fairly trivial change starts by at least filtering for text with http in.

This bit of cert would still break it. I guess we could match against URI:http to cover pretty much all eventualities such as these:
```
                CA Issuers - URI:ldap:///CN=HTTP%20servers,CN=bar,DC=foo,DC=example?cACertificate?base?objectClass=certificationAuthority
                CA Issuers - URI:http://foo.example/bar.crt
```