### PR TITLE
Bug fix: Outputting serial one time with `--long-output all` is enough

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -22,7 +22,7 @@
 VERSION=1.132.0
 SHORTNAME="SSL_CERT"
 
-VALID_ATTRIBUTES=",startdate,enddate,subject,issuer,serial,modulus,serial,hash,email,ocsp_uri,fingerprint,"
+VALID_ATTRIBUTES=",startdate,enddate,subject,issuer,modulus,serial,hash,email,ocsp_uri,fingerprint,"
 
 SIGNALS="HUP INT QUIT TERM ABRT"
 


### PR DESCRIPTION
VALID_ATTRIBUTES is used as the list what to output with `--long-output all`. A duplicate entry also causes a duplicate in the output.

Introduced 97d7bf112e14640ed9e0d7e4bef38bd29da52ddd (tag: v1.18.0)