### PR TITLE
Make HTTP request URL configurable

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-02-17  Robin Pronk  <robin.pronk@nedap.com>
+
+	* check_ssl_cert: Make HTTP request url configurable (default stays /)
+
 2021-02-05  Matteo Corti  <matteo@corti.li>
 
 	* check_ssl_cert (main): Adds a check for grep (to check if basic utilities are in the PATH)

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Options:
       --tls1_1                     force TLS version 1.1
       --tls1_2                     force TLS version 1.2
       --tls1_3                     force TLS version 1.3
+   -u,--url                        HTTP request url
    -v,--verbose                    verbose output
    -V,--version                    version
    -w,--warning days               minimum number of days a certificate has to be valid

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -179,6 +179,7 @@ usage() {
     echo "      --tls1_1                     force TLS version 1.1"
     echo "      --tls1_2                     force TLS version 1.2"
     echo "      --tls1_3                     force TLS version 1.3"
+    echo "   -u,--url                        HTTP request url"
     echo "   -v,--verbose                    verbose output"
     echo "   -V,--version                    version"
     echo "   -w,--warning days               minimum number of days a certificate has to be valid"
@@ -1382,6 +1383,7 @@ main() {
     PROXY=""
     CRL=""
     SCT="1" # enabled by default
+    HTTP_REQUEST_URL="/"
 
     # after 2020-09-01 we could set the default to 398 days because of Apple
     # https://support.apple.com/en-us/HT211025
@@ -1804,6 +1806,11 @@ main() {
             --temp)
                 check_option_argument '--temp' "$2"
                 TMPDIR="$2"
+                shift 2
+                ;;
+            -u|--url)
+                check_option_argument '-u|--url' "$2"
+                HTTP_REQUEST_URL="$2"
                 shift 2
                 ;;
             -w|--warning)
@@ -2479,7 +2486,7 @@ main() {
         CUSTOM_HTTP_HEADER="${CUSTOM_HTTP_HEADER}\\n"
     fi
 
-    HTTP_REQUEST="${HTTP_METHOD} / HTTP/1.1\\nHost: ${HOST_HEADER}\\nUser-Agent: check_ssl_cert/${VERSION}\\n${CUSTOM_HTTP_HEADER}Connection: close\\n\\n"
+    HTTP_REQUEST="${HTTP_METHOD} ${HTTP_REQUEST_URL} HTTP/1.1\\nHost: ${HOST_HEADER}\\nUser-Agent: check_ssl_cert/${VERSION}\\n${CUSTOM_HTTP_HEADER}Connection: close\\n\\n"
 
     ##############################################################################
     # Check for disallowed protocols


### PR DESCRIPTION
The HTTP request url used in the ssl certificate check shouldn't matter for the check it self as the certificate is on (virtual) host level.
However the (app) server behind it might react in an undesired way when hitting `/` for this health check, eg errors in log files.
This PR makes it configurable with the `-u` parameter. When that's not given it will use `/` which was hardcoded before and thus this is fully backward compatible. 

## Proposed Changes

  - Make HTTP request URL for either HEAD or GET request configurable, defaults to `/` (which was hard coded before)

## Testing

```
./check_ssl_cert --host test.host --cn test.host --sni test.host --port 443 --warning 14 --critical 5 --rootcert /etc/ssl/certs --altnames -d
...
[DBG] test.host is not an IP address
[DBG] executing with timeout (120s): printf 'HEAD / HTTP/1.1
[DBG] Host: test.host
[DBG] User-Agent: check_ssl_cert/1.136.0
[DBG] Connection: close
[DBG]
[DBG] ' | /usr/bin/openssl s_client    -crlf -ign_eof  -connect test.host:443 -servername test.host   -showcerts -verify 6 -CApath /etc/ssl/certs      2> /tmp/3tZ6xp 1> /tmp/TKIzgy
[DBG] /usr/bin/timeout 120 /bin/sh -c "printf 'HEAD / HTTP/1.1
[DBG] Host: test.host
[DBG] User-Agent: check_ssl_cert/1.136.0
[DBG] Connection: close
...
```

vs with `-u /status`
./check_ssl_cert --host test.host --cn test.host --sni test.host --port 443 --warning 14 --critical 5 --rootcert /etc/ssl/certs --altnames -u /status -d
```
[DBG] test.host is not an IP address
[DBG] executing with timeout (120s): printf 'HEAD /status HTTP/1.1
[DBG] Host: test.host
[DBG] User-Agent: check_ssl_cert/1.136.0
[DBG] Connection: close
[DBG]
[DBG] ' | /usr/bin/openssl s_client    -crlf -ign_eof  -connect test.host:443 -servername test.host   -showcerts -verify 6 -CApath /etc/ssl/certs      2> /tmp/3tZ6xp 1> /tmp/TKIzgy
[DBG] /usr/bin/timeout 120 /bin/sh -c "printf 'HEAD /status HTTP/1.1
[DBG] Host: test.host
[DBG] User-Agent: check_ssl_cert/1.136.0
[DBG] Connection: close
```
