### PR TITLE
--inetproto parameter and broken pipe error

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Options:
       --ignore-sct                 do not check for signed certificate timestamps (SCT)
       --ignore-ssl-labs-cache      Forces a new check by SSL Labs (see -L)
       --ignore-tls-renegotiation   Ignores the TLS renegotiation check
-      --Inetproto protocol         Force IP version 4 or 6
+      --inetproto protocol         Force IP version 4 or 6
    -i,--issuer issuer              pattern to match the issuer of the certificate
       --issuer-cert-cache dir      directory where to store issuer certificates cache
    -K,--clientkey path             use client certificate key to authenticate

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -1625,6 +1625,11 @@ main() {
                 DIG_BIN="$2"
                 shift 2
                 ;;
+            --inetproto)
+                check_option_argument '--inetproto' "$2"
+                INETPROTO="-$2"
+                shift 2
+                ;;
             --nmap-bin)
                 check_option_argument '--nmap-bin' "$2"
                 NMAP_BIN="$2"
@@ -2810,7 +2815,7 @@ main() {
     fi
 
     # shellcheck disable=SC2086
-    SIGNATURE_ALGORITHM="$(${OPENSSL} "${OPENSSL_COMMAND}" ${OPENSSL_PARAMS} -in "${CERT}" -text -noout | grep 'Signature Algorithm' | head -n 1)"
+    SIGNATURE_ALGORITHM="$(${OPENSSL} "${OPENSSL_COMMAND}" ${OPENSSL_PARAMS} -in "${CERT}" -text -noout | grep -m 1 -F 'Signature Algorithm')"
 
     if [ -n "${DEBUG}" ] ; then
         debuglog "${SUBJECT}"


### PR DESCRIPTION
Hi,
i am currently implementing this plugin to my monitoring stack and fixed to bugs. I want to contribute my bugfixes.

First, the `--inetproto` parameter was documented, but was not present in the script - i fixed this with a few additional lines of code.

Second, there was a strange behaviour with a grep command - it returned random something like "grep: write error: broken pipe". Turns out, that this behaviour came from the folowing `head` command, which exited before the complete output of grep was piped. I fixed this in form of removing the head command and giving a `-m` parameter to grep. This has the same effect and prevents the broken pipe.

`make test` returned no errors, so i want to please you to merge my fixes.

Thanks!