### PR TITLE
Update check_ssl_cert

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -1418,7 +1418,7 @@ fetch_certificate() {
         debuglog "$(sed 's/^/SSL error: /' "${ERROR}")"
 
         # s_client could verify the server certificate because the server requires a client certificate
-        if ascii_grep '^Acceptable client certificate CA names' "${CERT}" ; then
+        if ascii_grep '^Client Certificate Types' "${CERT}" ; then
 
             verboselog "The server requires a client certificate"
 


### PR DESCRIPTION
Replaced search string 'Acceptable client certificate CA names' with 'Client Certificate Types' to also catch rare cases, where a server requests a client certificate but does not specifiy an acceptable CA.

Fixes #
https://github.com/matteocorti/check_ssl_cert/issues/268