### PR TITLE
Fixes for LibreSSL 2.8.3 on macOS Catalina

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-05-28  Igor Mironov  <mcs6502-sek@yahoo.com.au>
+
+	* check_ssl_cert: compatibility fixes for LibreSSL 2.8.3 on macOS Catalina
+
 2021-05-21  Matteo Corti  <matteo@corti.li>
 
 	* check_ssl_cert: added the --debug-file option

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -426,7 +426,7 @@ EOF
         OPENSSL_VERSION=$( ${OPENSSL} version )
     fi
     debuglog "openssl version: ${OPENSSL_VERSION}"
-    OPENSSL_VERSION=$( echo "${OPENSSL_VERSION}" | sed 's/^OpenSSL\ \([^ \-]*\).*/\1/' )
+    OPENSSL_VERSION=$( echo "${OPENSSL_VERSION}" | sed -E 's/^(Libre|Open)SSL\ ([^ \-]*).*/\2/' )
 
     IFS='.' read -r MAJOR1 MAJOR2 MINOR <<EOF
 ${OPENSSL_VERSION}
@@ -3894,7 +3894,7 @@ main() {
 
             debuglog 'Checking Signed Certificate Timestamps (SCTs)'
 
-	    if [ -n "${SCT}" ] && ! "${OPENSSL}" x509 -in "${CERT}" -text -noout | grep -F -q 'SCTs' ; then
+	    if [ -n "${SCT}" ] && ! "${OPENSSL}" x509 -in "${CERT}" -text -noout | grep -E -q 'SCTs|1\.3\.6\.1\.4\.1\.11129\.2\.4\.2' ; then
                 prepend_critical_message "Cannot find Signed Certificate Timestamps (SCT)"
             fi
 


### PR DESCRIPTION
Hi Matteo, this is a quick fix for a couple of issues observed when using check_ssl_cert on macOS Catalina with stock openssl (LibreSSL 2.8.3). With this fix only 10 tests out of 89 failed on a test machine, compared to 78 failing initially.

Fixes # (I haven't raised a defect report)
```
$ ./check_ssl_cert -H internic.net
./check_ssl_cert: line 445: [: LibreSSL 2: integer expression expected
./check_ssl_cert: line 447: [: LibreSSL 2: integer expression expected
SSL_CERT CRITICAL internic.net: Cannot find Signed Certificate Timestamps (SCT)|days_chain_elem1=196;20;15;; days_chain_elem2=3405;20;15;; 

$ openssl version
LibreSSL 2.8.3

$ git stash pop
…

$ ./check_ssl_cert -H internic.net
SSL_CERT OK - x509 certificate 'internic.net' from 'DigiCert TLS RSA SHA256 2020 CA1' valid until Dec 10 23:59:59 2021 GMT (expires in 196 days)|days_chain_elem1=196;20;15;; days_chain_elem2=3405;20;15;;
```
## Proposed Changes

  - use "sed -E" to allow for LibreSSL (note sed regexes are already used in a couple of places in the script so should be ok)
  - use numeric OID for SCT extension, which LibreSSL didn't recognise. I followed the example in https://github.com/drwetter/testssl.sh/blob/3.1dev/testssl.sh
