### PR TITLE
bugfix: Check for Signed Certificate Timestamps (SCT) produced an error when checking a CRL

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2021-09-17 Bernd Stroessenreuther <booboo@gluga.de>
 
+	* test/unit_tests.sh: fixing error with endless ping if IPv6 enabled
+
+2021-09-17 Bernd Stroessenreuther <booboo@gluga.de>
+
 	* check_ssl_cert: fixing error with SCT when checking a CRL file
 
 2021-09-17  Matteo Corti  <matteo@corti.li>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-09-17 Bernd Stroessenreuther <booboo@gluga.de>
+
+	* check_ssl_cert: fixing error with SCT when checking a CRL file
+
 2021-09-17  Matteo Corti  <matteo@corti.li>
 
 	* test/unit_tests.sh (testPrometheus): added test for --prometheus

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -4196,7 +4196,7 @@ main() {
 
     ##############################################################################
     # Check for Signed Certificate Timestamps (SCT)
-    if [ -z "${SELFSIGNED}" ] ; then
+    if [ -z "${SELFSIGNED}" ] && [ "${OPENSSL_COMMAND}" != "crl" ]; then
 
         # check if OpenSSL supoort SCTs
         if openssl_version '1.1.0' ; then

--- a/test/unit_tests.sh
+++ b/test/unit_tests.sh
@@ -597,7 +597,7 @@ testIPv6() {
 
 	    echo "IPv6 is configured"
 
-            if ping -6 www.google.com > /dev/null 2>&1  ; then
+            if ping -c 3 -6 www.google.com > /dev/null 2>&1  ; then
 
                 ${SCRIPT} --rootcert-file cabundle.crt -H www.google.com -6 --critical 1 --warning 2
                 EXIT_CODE=$?


### PR DESCRIPTION
calls like
    ./check_ssl_cert -f digicert.crl.pem -w 1 -c 0
broke the check script.
This is now fixed - Check for Signed Certificate Timestamps is not needed when looking at CRL files.
