### PR TITLE
test/unit_tests.sh: adding tests for using floating point numbers in thresholds

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-09-25 Bernd Stroessenreuther <booboo@gluga.de>
+
+	* test/unit_tests.sh: adding tests for using floating point numbers in thresholds
+
 2021-09-24 Bernd Stroessenreuther <booboo@gluga.de>
 
 	* check_ssl_cert: --warning and --critical now also accept floating point numbers

--- a/test/unit_tests.sh
+++ b/test/unit_tests.sh
@@ -968,6 +968,22 @@ testGithubComCRL () {
 
 }
 
+testFloatingPointThresholds () {
+
+    ${SCRIPT} -H github.com --warning 2.5 --critical 1.5
+    EXIT_CODE=$?
+    assertEquals "wrong exit code" "${NAGIOS_OK}" "${EXIT_CODE}"
+
+}
+
+testFloatingPointThresholdsWrongUsage () {
+
+    ${SCRIPT} -H github.com --warning 1.5 --critical 2.5
+    EXIT_CODE=$?
+    assertEquals "expecting error message about --warning is less or equal --critical, but got wrong exit code, " "${NAGIOS_UNKNOWN}" "${EXIT_CODE}"
+
+}
+
 # the script will exit without executing main
 export SOURCE_ONLY='test'
 


### PR DESCRIPTION
There should be at least some basic tests for using floating point numbers in thresholds. Providing these.
