### PR TITLE
Improve nmap speed to detect IPv6-only hosts

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -3915,7 +3915,7 @@ main() {
     if [ -n "${DISALLOWED_PROTOCOLS}" ]; then
 
         # check if the host has an IPv6 address only (as nmap is not able to resolve without the -6 switch
-        if ${NMAP_BIN} "${HOST_ADDR}" 2>&1 | grep -F -q 'Failed to resolve'; then
+        if ${NMAP_BIN} -Pn -p "${PORT}" "${HOST_ADDR}" 2>&1 | grep -F -q 'Failed to resolve'; then
             debuglog "nmap is not able to resolve the host name (${HOST_ADDR}). Trying with -6 to force IPv6 for an IPv6-only host"
 
             NMAP_INETPROTO='-6'


### PR DESCRIPTION
Fixes # Issue not reported yet

## Proposed Changes

nmap performs a port scan to detect if it can resolve the address of the
host. If it fails it tries to force IPv6. This change tells nmap to scan
only the required port. This reduces the required time and reduces the
possibility to be falsely detected by an IDS.