### PR TITLE
Ensure CURL_BIN exists before calling it

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -4010,7 +4010,7 @@ main() {
             HTTPS_PROXY="${HTTP_PROXY}"
         fi
 
-        if ${CURL_BIN} --manual | grep -F -q -- --proxy; then
+        if [ ! -z "${CURL_BIN}" ] && [ ${CURL_BIN} --manual | grep -F -q -- --proxy ]; then
             debuglog "Adding --proxy ${HTTP_PROXY} to the curl options"
             CURL_PROXY="--proxy"
             CURL_PROXY_ARGUMENT="${HTTP_PROXY}"


### PR DESCRIPTION
Fixes probably just a weird workflow we've caused with a custom protocol behaviour, but seems like an easy enough fix to be worth adding anyway.

Otherwise you get the following:
`./check_ssl_cert: 4014: ./check_ssl_cert: --manual: not found`