### PR TITLE
Strip the IP Address label from SAN entries too

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -1292,6 +1292,7 @@ extract_cert_attribute() {
             grep -F -A 1 "509v3 Subject Alternative Name:" |
             tail -n 1 |
             sed -e "s/DNS://g" |
+            sed -e "s/IP Address://g" |
             sed -e "s/,//g" |
             sed -e 's/^\ *//'
         ;;


### PR DESCRIPTION
Fixes some odd logging if you have a SAN entry which is an IP address, where it breaks it on the space so it checks your SAN for "IP".