### PR TITLE
Add the proxy options during the renegotiation checks

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -4403,11 +4403,11 @@ main() {
             TIMEOUT_REASON="checking TLS renegotiation"
             case "${PROTOCOL}" in
             pop3 | ftp | smtp | irc | ldap | imap | postgres | sieve | xmpp | xmpp-server | mysql)
-                exec_with_timeout "printf 'R\\n' | ${OPENSSL} s_client ${INETPROTO} -crlf -connect ${HOST_ADDR}:${PORT} -starttls ${PROTOCOL} 2>&1 | grep -F -q err"
+                exec_with_timeout "printf 'R\\n' | ${OPENSSL} s_client ${INETPROTO} -crlf -connect ${HOST_ADDR}:${PORT} ${SERVERNAME} ${SCLIENT_PROXY} ${SCLIENT_PROXY_ARGUMENT} -starttls ${PROTOCOL} 2>&1 | grep -F -q err"
                 RET=$?
                 ;;
             *)
-                exec_with_timeout "printf 'R\\n' | ${OPENSSL} s_client ${INETPROTO} -crlf -connect ${HOST_ADDR}:${PORT} 2>&1 | grep -F -q err"
+                exec_with_timeout "printf 'R\\n' | ${OPENSSL} s_client ${INETPROTO} -crlf -connect ${HOST_ADDR}:${PORT} ${SERVERNAME} ${SCLIENT_PROXY} ${SCLIENT_PROXY_ARGUMENT} 2>&1 | grep -F -q err"
                 RET=$?
                 ;;
             esac


### PR DESCRIPTION
I'm unclear if SERVERNAME is actually required or not, but I figured it might be...

Also FWIW I get the following:
```
printf 'R
' | /usr/bin/openssl s_client  -crlf -connect www.github.com:443 -servername www.github.com -proxy proxy.example.com:80 2>&1 | grep -F err
140385676227904:error:1420410A:SSL routines:SSL_renegotiate:wrong ssl version:../ssl/ssl_lib.c:2133:

/usr/bin/timeout 120 /bin/sh -c "printf 'R
' | /usr/bin/openssl s_client  -crlf -connect www.github.com:443 -servername www.github.com -proxy proxy.example.com:80 2>&1 | grep -F -q err"; echo $?
0

/usr/bin/timeout 120 /bin/sh -c "printf 'R
' | /usr/bin/openssl s_client  -crlf -connect www.github.com:443 -servername www.github.com -proxy proxy.example.com:80 2>&1 | grep -F -q errINVALID"; echo $?
1
```

I'm a bit unclear if that line should actually be matching the grep and counting as success rather than failure? Or maybe it's my proxy causing that issue anyway...

Run as:
```
./check_ssl_cert -H www.github.com --proxy proxy.example.com:80
SSL_CERT OK - www.github.com:443, https, x509 certificate 'github.com' (www.github.com) from 'DigiCert Inc' valid until Mar 15 23:59:59 2023 GMT (expires in 361 days)|days_chain_elem1=361;20;15;; days_chain_elem2=3312;20;15;;
```