### PR TITLE
Fix the message for something that expired more than 24 hours ago

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -1902,7 +1902,7 @@ check_cert_end_date() {
         # We always check expired certificates
         debuglog "executing: ${OPENSSL} x509 -noout -checkend 0 on cert element ${el_number} (${element_cn})"
         if ! echo "${1}" | ${OPENSSL} x509 -noout -checkend 0 >/dev/null; then
-            if compare "${ELEM_DAYS_VALID}" "<" 1; then
+            if compare "${ELEM_DAYS_VALID}" ">=" 0 && compare "${ELEM_DAYS_VALID}" "<" 1; then
                 DAYS_AGO='less than a day ago'
             else
                 DAYS_AGO="$((-ELEM_DAYS_VALID)) days ago"


### PR DESCRIPTION
Fixes #375

I've not actually checked if this works for something that is less than 24 hours old...