### PR TITLE
Interpret newlines in prometheus_output

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -924,7 +924,7 @@ prometheus_output() {
     if [ -n "${PROMETHEUS_OUTPUT_STATUS}" ]; then
         echo "# HELP cert_valid   If cert is ok (0), warning (1) or critical (2)"
         echo "# TYPE cert_valid gauge"
-        echo "${PROMETHEUS_OUTPUT_STATUS}"
+        printf '%b\n' "${PROMETHEUS_OUTPUT_STATUS}"
         NL=1
     fi
 
@@ -934,7 +934,7 @@ prometheus_output() {
         fi
         echo "# HELP cert_valid_chain_elem  If chain element is ok (0), warning (1) or critical (2)"
         echo "# TYPE cert_valid_chain_elem gauge"
-        echo "${PROMETHEUS_OUTPUT_VALID}"
+        printf '%b\n' "${PROMETHEUS_OUTPUT_VALID}"
         NL=1
     fi
 
@@ -944,7 +944,7 @@ prometheus_output() {
         fi
         echo "# HELP cert_days_chain_elem Days until chain element expires"
         echo "# TYPE cert_days_chain_elem gauge"
-        echo "${PROMETHEUS_OUTPUT_DAYS}"
+        printf '%b\n' "${PROMETHEUS_OUTPUT_DAYS}"
     fi
 }
 


### PR DESCRIPTION
Fixes newlines not being interpreted in prometheus_output causing multiple lines being outputed as a single line with literal "\n"

Before

```
./check_ssl_cert --prometheus -H google.com
# HELP cert_valid   If cert is ok (0), warning (1) or critical (2)
# TYPE cert_valid gauge
cert_valid{cn="*.google.com"} 0

# HELP cert_valid_chain_elem  If chain element is ok (0), warning (1) or critical (2)
# TYPE cert_valid_chain_elem gauge
cert_valid_chain_elem{cn="*.google.com", element="1"} 0\ncert_valid_chain_elem{cn="*.google.com", element="2"} 0\ncert_valid_chain_elem{cn="*.google.com", element="3"} 0

# HELP cert_days_chain_elem Days until chain element expires
# TYPE cert_days_chain_elem gauge
cert_days_chain_elem{cn="*.google.com", element="1"} 67\ncert_days_chain_elem{cn="*.google.com", element="2"} 1937\ncert_days_chain_elem{cn="*.google.com", element="3"} 2057
```

After

```
./check_ssl_cert --prometheus -H google.com
# HELP cert_valid   If cert is ok (0), warning (1) or critical (2)
# TYPE cert_valid gauge
cert_valid{cn="*.google.com"} 0

# HELP cert_valid_chain_elem  If chain element is ok (0), warning (1) or critical (2)
# TYPE cert_valid_chain_elem gauge
cert_valid_chain_elem{cn="*.google.com", element="1"} 0
cert_valid_chain_elem{cn="*.google.com", element="2"} 0
cert_valid_chain_elem{cn="*.google.com", element="3"} 0

# HELP cert_days_chain_elem Days until chain element expires
# TYPE cert_days_chain_elem gauge
cert_days_chain_elem{cn="*.google.com", element="1"} 67
cert_days_chain_elem{cn="*.google.com", element="2"} 1937
cert_days_chain_elem{cn="*.google.com", element="3"} 2057
```