### PR TITLE
Hacky fix for nmap not working behind a proxy

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -4641,7 +4641,7 @@ main() {
 
         debuglog "Executing: '${NMAP_BIN} ${NMAP_INETPROTO} -Pn -p ${PORT} ${NMAP_HOST_ADDR}'"
 
-        if ! ${NMAP_BIN} "${NMAP_INETPROTO}" -Pn -p "${PORT}" "${NMAP_HOST_ADDR}" 2>&1 | grep -q "${PORT}.*open" ; then
+        if ! ${NMAP_BIN} "${NMAP_INETPROTO}" -Pn -p "${PORT}" "${NMAP_HOST_ADDR}" 2>&1 | grep -E -q "${PORT}.*(?>open|filtered)" ; then
 
             if [ -n "${IGNORE_CONNECTION_STATE}" ] ; then
 

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -4641,7 +4641,7 @@ main() {
 
         debuglog "Executing: '${NMAP_BIN} ${NMAP_INETPROTO} -Pn -p ${PORT} ${NMAP_HOST_ADDR}'"
 
-        if ! ${NMAP_BIN} "${NMAP_INETPROTO}" -Pn -p "${PORT}" "${NMAP_HOST_ADDR}" 2>&1 | grep -E -q "${PORT}.*(?>open|filtered)" ; then
+        if ! ${NMAP_BIN} "${NMAP_INETPROTO}" -Pn -p "${PORT}" "${NMAP_HOST_ADDR}" 2>&1 | grep -E -q "${PORT}.*(open|filtered)" ; then
 
             if [ -n "${IGNORE_CONNECTION_STATE}" ] ; then
 


### PR DESCRIPTION
nmap doesn't work properly behind a proxy.

See e.g.
https://subscription.packtpub.com/book/networking-and-servers/9781786467454/2/ch02lvl1sec37/scanning-through-proxies
https://security.stackexchange.com/questions/120708/nmap-through-proxy

I wonder if we actually just need to skip these checks when the user has given a proxy?

There are also some other nmap based checks for SSL cypher types we'll need to check if they work still...