### PR TITLE
Default to python3 in PYTHON_BIN

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -4216,7 +4216,7 @@ main() {
     # Python is needed for TDS
     if [ -n "${PROTOCOL}" ] && [ "${PROTOCOL}" = 'tds' ]; then
         if [ -z "${PYTHON_BIN}" ]; then
-            PYTHON_BIN='python'
+            PYTHON_BIN='python3'
         fi
         check_required_prog "${PYTHON_BIN}"
         PYTHON_BIN="${PROG}"


### PR DESCRIPTION
Since we only support python3, let's point to python3 to be more explicit.

Also see PEP 394:
https://peps.python.org/pep-0394/

Fixes #424