### PR TITLE
added --ignore-root-present

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # check\_ssl\_cert
 
- &copy; Matteo Corti, ETH Zurich, 2007-2012.  
+ &copy; Matteo Corti, ETH Zurich, 2007-2012.
  &copy; Matteo Corti, 2007-2023.
 
  see [AUTHORS.md](AUTHORS.md) for the complete list of contributors
@@ -133,6 +133,7 @@ Options:
                                    checked
       --ignore-ocsp-timeout        Ignore OCSP result when timeout occurs
                                    while checking
+      --ignore-root-present        Ignore root certificate in the chain
       --ignore-sct                 Do not check for signed certificate
                                    timestamps (SCT)
       --ignore-sig-alg             Do not check if the certificate was signed

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -3086,6 +3086,10 @@ parse_command_line_options() {
             IGNORE_TLS_RENEGOTIATION='1'
             shift
             ;;
+            --ignore-root-present)
+            IGNORE_ROOT_PRESENT='1'
+            shift
+            ;;
         --info)
             INFO='1'
             shift
@@ -5653,7 +5657,7 @@ EOF
         if [ "${matches}" -eq 1 ]; then
             debuglog "The root certificate is present in the chain"
             verboselog "The root certificate is unnecessarily present in the delivered certificate chain"
-            if [ -n "${CHECK_CHAIN}" ]; then
+            if [ -n "${CHECK_CHAIN}" ] && ! [ -n "${IGNORE_ROOT_PRESENT}" ] ; then
                 prepend_critical_message "The root certificate is unnecessarily present in the delivered certificate chain"
             fi
         fi

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -5657,7 +5657,7 @@ EOF
         if [ "${matches}" -eq 1 ]; then
             debuglog "The root certificate is present in the chain"
             verboselog "The root certificate is unnecessarily present in the delivered certificate chain"
-            if [ -n "${CHECK_CHAIN}" ] && ! [ -n "${IGNORE_ROOT_PRESENT}" ] ; then
+            if [ -n "${CHECK_CHAIN}" ] && [ -z "${IGNORE_ROOT_PRESENT}" ] ; then
                 prepend_critical_message "The root certificate is unnecessarily present in the delivered certificate chain"
             fi
         fi

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -334,6 +334,7 @@ usage() {
     echo "                                   checked"
     echo "      --ignore-ocsp-timeout        Ignore OCSP result when timeout occurs"
     echo "                                   while checking"
+    echo "      --ignore-root-present        Ignore root certificate in the chain"
     echo "      --ignore-sct                 Do not check for signed certificate"
     echo "                                   timestamps (SCT)"
     echo "      --ignore-sig-alg             Do not check if the certificate was signed"
@@ -3086,7 +3087,7 @@ parse_command_line_options() {
             IGNORE_TLS_RENEGOTIATION='1'
             shift
             ;;
-            --ignore-root-present)
+        --ignore-root-present)
             IGNORE_ROOT_PRESENT='1'
             shift
             ;;

--- a/check_ssl_cert.1
+++ b/check_ssl_cert.1
@@ -223,6 +223,9 @@ Continue if the OCSP status cannot be checked
 .BR "   --ignore-ocsp-timeout"
 Ignore OCSP result when timeout occurs while checking
 .TP
+.BR "   --ignore-root-present"
+Ignore root certificate in the chain
+.TP
 .BR "   --ignore-sct"
 Do not check for signed certificate timestamps (SCT)
 .TP

--- a/utils/help.txt
+++ b/utils/help.txt
@@ -86,6 +86,7 @@
 --ignore-ocsp-timeout;Ignore OCSP result when timeout occurs
 --ignore-ocsp-timeout;while checking
 --ignore-ocsp;Do not check revocation with OCSP
+--ignore-root-present;Ignore root certificate in the chain
 --ignore-sct;Do not check for signed certificate
 --ignore-sct;timestamps (SCT)
 --ignore-sig-alg;Do not check if the certificate was signed


### PR DESCRIPTION
Many of our ssl-certificates have the root-certificate in the chain submitted via SSLCertificateChainFile. So I wanted to skip that critical message.
Feel free to correct the changes, if needed.

Fixes #

## Proposed Changes

  -
  -
  -
