### PR TITLE
Fix inconsistent output format in openssl x509 command (crl_uri)

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -1562,9 +1562,9 @@ extract_cert_attribute() {
         ;;
     crl_uri)
         echo "${cert_content}" | "${OPENSSL}" x509 -noout -text |
-            "${GREP_BIN}" -F -A 4 'X509v3 CRL Distribution Points' |
-            "${GREP_BIN}" -F URI |
-            sed 's/^.*URI://'
+            "${GREP_BIN}" -A 4 'X509v3 CRL Distribution Points' |
+            "${GREP_BIN}" -o -P 'URI:\K\S+' |
+            head -n 1
         ;;
     version)
         echo "${cert_content}" | "${OPENSSL}" x509 -noout -text | "${GREP_BIN}" Version | head -n 1 | sed 's/.*Version: //'


### PR DESCRIPTION
The output of the `openssl x509` command with the `-text` and `-noout` options has changed between OpenSSL versions 1.1 and 3.0. Specifically, the output format of the "X509v3 CRL Distribution Points" section has changed. This commit updates the script to use a more robust and future-proof command that works with both versions.

The old output format looked like this:
```
            X509v3 CRL Distribution Points:

                Full Name:
                  URI:http://crl.usertrust.com/USERTrustRSACertificationAuthority.crl

            Authority Information Access:
                CA Issuers - URI:http://crt.usertrust.com/USERTrustRSAAddTrustCA.crt
```
The new output format looks like this:
```
            X509v3 CRL Distribution Points:
                Full Name:
                  URI:http://crl.usertrust.com/USERTrustRSACertificationAuthority.crl
            Authority Information Access:
                CA Issuers - URI:http://crt.usertrust.com/USERTrustRSAAddTrustCA.crt
```

Here's an example of it returning multipe URIs due to the change in output between 1.1 and 3.0:
```
# openssl x509 -in test.txt -text -noout | grep -F -A 4 'X509v3 CRL Distribution Points' | grep -F URI | sed 's/^.*URI://'
http://crl.usertrust.com/USERTrustRSACertificationAuthority.crl
http://crt.usertrust.com/USERTrustRSAAddTrustCA.crt
```

With my suggested changes:
```
# openssl x509 -in testy.txt -text -noout | grep -A 4 'X509v3 CRL Distribution Points' | grep -o -P 'URI:\K\S+' | head -n 1
http://crl.usertrust.com/USERTrustRSACertificationAuthority.crl
```
