### PR TITLE
Fix usage of --do-not-resolve

### DIFF
--- a/check_ssl_cert_icinga2.conf
+++ b/check_ssl_cert_icinga2.conf
@@ -165,7 +165,7 @@ object CheckCommand "ssl_cert_extended" {
 		}
 
 		"--do-not-resolve" = {
-			value = "$ssl_cert_extended_do_not_resolve$"
+			set_if = "$ssl_cert_extended_do_not_resolve$"
 			description = "Do not check if the host can be resolved"
 		}
 


### PR DESCRIPTION
`--do-not-resolve` is a simple bool flag without a value.