### PR TITLE
check_ssl_cert_icinga2.conf: Fix syntax error near --nmap-wiht-proxy

### DIFF
--- a/check_ssl_cert_icinga2.conf
+++ b/check_ssl_cert_icinga2.conf
@@ -395,7 +395,7 @@ object CheckCommand "ssl_cert_extended" {
 		}
 
 		"--nmap-with-proxy" = {
-			value = "$ssl_cert_extended_nmap_with_proxy"
+			value = "$ssl_cert_extended_nmap_with_proxy$"
 			description = "Allow nmap to be used with a proxy"
 		}
 


### PR DESCRIPTION
Fixes a syntax when parsing the Icinga 2 config due to a missing `$`.
