### PR TITLE
Allow empty argument for --dane

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -4033,7 +4033,10 @@ $2"
             if [ $# -gt 1 ]; then
 
                 # shellcheck disable=SC2295
-                if [ "${2%${2#?}}"x = '-x' ]; then
+                if [ -z "$2" ]; then
+                    DANE=1
+                    shift 2
+                elif [ "${2%${2#?}}"x = '-x' ]; then
                     DANE=1
                     shift
                 else


### PR DESCRIPTION
The "--dane" option can be used both as a flag and with an argument. In its current implementation, it is even a special case for flags with variable numbers of arguments.

At an Icinga 2 ITL PR by GitHub user @peteeckel, an unexpected behavior was seen when calling check_ssl_cert with "--dane" followed by an empty argument[^0], as so:

$ ./check_ssl_cert --dane ""

If the empty argument was used, the --dane option was effectively useless. This is due to the argument counting/checking code, not expecting an empty second argument, setting DANE="", which disables it.

This change allows an empty second argument, which will then be swallowed. For the other options with variable numbers of arguments, this does not seem to apply.

[^0]: https://github.com/Icinga/icinga2/pull/10196#discussion_r1840123628