### PR TITLE
check_ssl_cert_icinga2.conf: Fix --ignore-dh

### DIFF
--- a/check_ssl_cert_icinga2.conf
+++ b/check_ssl_cert_icinga2.conf
@@ -270,8 +270,8 @@ object CheckCommand "ssl_cert_extended" {
 		}
 
 		"--ignore-dh" = {
-			set_if = "$ssl_cert_extended_ignore_dh"
-			description = "[state] Ignore too small DH keys""
+			set_if = "$ssl_cert_extended_ignore_dh$"
+			description = "[state] Ignore too small DH keys"
 		}
 
         "--ignore-exp" = {


### PR DESCRIPTION
The recently introduced --ignore-dh CheckCommand argument came with syntax errors, resulting in being rejected by Icinga 2 after the update.

> [2025-03-07 08:47:10 +0100] critical/config: Error: Unterminated string literal
> Location: in /etc/icinga2/conf.d/commands_check_ssl_cert.conf: 274:52-275:0
> /etc/icinga2/conf.d/commands_check_ssl_cert.conf(272):   "--ignore-dh" = {
> /etc/icinga2/conf.d/commands_check_ssl_cert.conf(273):    set_if = "$ssl_cert_extended_ignore_dh"
> /etc/icinga2/conf.d/commands_check_ssl_cert.conf(274):    description = "[state] Ignore too small DH keys""
>                                                                                                           ^
> /etc/icinga2/conf.d/commands_check_ssl_cert.conf(275):   }
>
> /etc/icinga2/conf.d/commands_check_ssl_cert.conf(276):
> /etc/icinga2/conf.d/commands_check_ssl_cert.conf(277):         "--ignore-exp" = {
> [2025-03-07 08:47:10 +0100] critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.