### PR TITLE
fix parsing of nmap output

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -5875,12 +5875,12 @@ main() {
             if [ "${DEBUG}" -ge 1 ]; then
                 echo "${NMAP_OUTPUT}" | sed -e 's/^/[DBG]   /'
             fi
-            debuglog "${GREP_BIN} -q \"${PORT}.*open\""
+            debuglog "${GREP_BIN} -q \"open.*${PORT}\""
             if [ "${DEBUG}" -ge 1 ]; then
-                echo "${NMAP_OUTPUT}" | "${GREP_BIN}" -q "${PORT}.*open" | sed -e 's/^/[DBG]   /'
+                echo "${NMAP_OUTPUT}" | "${GREP_BIN}" -q "open.*${PORT}" | sed -e 's/^/[DBG]   /'
             fi
 
-            if ! echo "${NMAP_OUTPUT}" | "${GREP_BIN}" -q "${PORT}.*open"; then
+            if ! echo "${NMAP_OUTPUT}" | "${GREP_BIN}" -q "open.*${PORT}"; then
 
                 if [ -n "${IGNORE_CONNECTION_STATE}" ]; then
 


### PR DESCRIPTION
the output of e.g., `/usr/bin/nmap --unprivileged -Pn -p smtps 192.168.2.2`  returns output in a different format than expected by the script
```
Starting Nmap 7.94SVN ( https://nmap.org ) at 2025-08-28 16:22 PDT
Nmap scan report for lorien.example.org (192.168.2.2)
Host is up (0.0014s latency).

PORT    STATE SERVICE
465/tcp open  smtps

Nmap done: 1 IP address (1 host up) scanned in 0.04 seconds
```
whereas  the script is `grep`ing for `"${PORT}.*open"` (i.e., reversed).  this patch changes the pattern to `"open.*${PORT}"`