### PR TITLE
Add BuildRequires

### DIFF
--- a/check_ssl_cert.spec
+++ b/check_ssl_cert.spec
@@ -23,6 +23,7 @@ URL:       https://github.com/matteocorti/check_ssl_cert
 Source:    https://github.com/matteocorti/check_ssl_cert/releases/download/v%{version}/check_ssl_cert-%{version}.tar.gz
 
 Requires:  nagios-plugins expect perl(Date::Parse) bc curl openssl file
+BuildRequires:  make tar coreutils
 
 %description
 A shell script (that can be used as a Nagios plugin) to check an SSL/TLS connection


### PR DESCRIPTION
When using mock it's possible not all or any build depends exist. Add BuildRequires.
- make
- coreutils
- tar

## Proposed Changes

  - Add build requirements to spec file.