### PR TITLE
Move `ASSUME_ONLINE` earlier in the script to avoid lookup of `NMAP_BIN`

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -5418,22 +5418,26 @@ main() {
 
         debuglog "nmap binary not specified"
 
-        # we check if nmap is available: if not we continue without connection checks and ciphers
-        NMAP_BIN=$(command -v nmap 2>/dev/null)
-        if [ -z "${NMAP_BIN}" ]; then
-            verboselog "cannot find nmap: disabling connection checks and ciphers checks"
-            debuglog "cannot find nmap: disabling connection checks and ciphers checks"
+        if [ -n "${ASSUME_ONLINE}" ]; then
+
+            debuglog "Not determining nmap binary, commanded not to use it"
             DISABLE_NMAP=1
 
-            if [ -n "${IGNORE_CONNECTION_STATE}" ] ; then
-                unknown "--ignore-connection-state requires nmap"
-            fi
-
         else
-            if [ ! -x "${NMAP_BIN}" ]; then
-                unknown "${NMAP_BIN} is not executable"
+
+            # we check if nmap is available: if not we continue without connection checks and ciphers
+            NMAP_BIN=$(command -v nmap 2>/dev/null)
+            if [ -z "${NMAP_BIN}" ]; then
+                verboselog "cannot find nmap: disabling connection checks and ciphers checks"
+                debuglog "cannot find nmap: disabling connection checks and ciphers checks"
+                DISABLE_NMAP=1
+
+            else
+                if [ ! -x "${NMAP_BIN}" ]; then
+                    unknown "${NMAP_BIN} is not executable"
+                fi
+                debuglog "nmap available: ${NMAP_BIN}"
             fi
-            debuglog "nmap available: ${NMAP_BIN}"
         fi
 
     else
@@ -5441,6 +5445,12 @@ main() {
         # we check if the provided binary actually works
         check_required_prog "${NMAP_BIN}"
 
+    fi
+
+    if [ -n "${DISABLE_NMAP}" ]; then
+        if [ -n "${IGNORE_CONNECTION_STATE}" ] ; then
+            unknown "--ignore-connection-state requires nmap"
+        fi
     fi
 
     # nmap does not understand brackets in IPv6 addresses
@@ -5948,8 +5958,7 @@ main() {
     # Connection check
     if [ -z "${FILE}" ]; then
 
-        if [ -n "${DISABLE_NMAP}" ] ||
-           [ -n "${ASSUME_ONLINE}" ] ; then
+        if [ -n "${DISABLE_NMAP}" ] ; then
 
             if [ -n "${USING_A_PROXY}" ] ; then
                 verboselog "Using a proxy: cannot test connection"


### PR DESCRIPTION
I upgraded from a very old `check_ssl_cert` to recent.  My security people came to me, "why are we now running `nmap` on this host?"  Turns out I missed `--assume-online`, enabled that.  They come back the next day, "ok you're not running `nmap` but rather `/usr/sbin/alternatives --display nmap`, can you stop /that/ to remove grep noise?"

Not urgent, obviously, but as I dug into it, it seems like a needless lookup / good cleanup opportunity.

The crux of the problem is, `ASSUME_ONLINE` is checked later than `NMAP_BIN` is evaluated / auto-calculated-if-not-specified-by-options.  This patch moves `ASSUME_ONLINE` earlier, causing the `NMAP_BIN` lookup to be skipped when `nmap` is not wanted, and setting `DISABLE_NMAP` so you don't have `DISABLE_NMAP` and `ASSUME_ONLINE` that mostly mean the same thing later.

Thanks for looking.