### PR TITLE
Clarify '--noauth' option description in check_ssl_cert.1

### DIFF
--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -293,7 +293,8 @@ usage() {
     echo "Options:"
     # Delimiter at 78 chars ############################################################
     echo "   -A,--noauth                     Ignore authority warnings (expiration"
-    echo "                                   only)"
+    echo "                                   only) to skip requirements for client"
+    echo "                                   certs"
     echo "      --all                        Enable all the possible optional checks"
     echo "                                   at the maximum level"
     echo "      --all-local                  Enable all the possible optional checks"

--- a/check_ssl_cert.1
+++ b/check_ssl_cert.1
@@ -21,7 +21,7 @@ server
 .SH OPTIONS
 .TP
 .BR "-A,--noauth"
-Ignore authority warnings (expiration only)
+Ignore authority warnings (expiration only) to skip requirements for client certs
 .TP
 .BR "    --all"
 Enable all the possible optional checks at the maximum level


### PR DESCRIPTION
Updated the description for the '--noauth' option to clarify its behaviour regarding client certificates.

I assume this is correct based on #14 or does it also have other "downsides"?