### PR TITLE
Handle decimal thresholds for recently expired certificates

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-07-16  Joey@macstudio  <4296411@qq.com>
+
+        * check_ssl_cert (check_cert_end_date): Handle decimal day values for
+                                                 certificates expired less than a day
+        * test/unit_tests.sh (testFloatingPointThresholdsRecentlyExpired): Add
+                                                                          a regression test
+
 2026-05-28  Matteo Corti  <matteo@corti.li>
 
         * check_ssl_cert (main): disabling -servername for IP addresses

--- a/check_ssl_cert
+++ b/check_ssl_cert
@@ -2500,7 +2500,7 @@ check_cert_end_date() {
 
         if ! checkend "${1}" 0 ; then
 
-            if compare "${ELEM_DAYS_VALID}" ">=" 0 && compare "${ELEM_DAYS_VALID}" "<" 1; then
+            if compare "${ELEM_DAYS_VALID}" ">" -1 && compare "${ELEM_DAYS_VALID}" "<" 1; then
                 DAYS_AGO='less than a day ago'
             else
                 # remove decimals

--- a/test/unit_tests.sh
+++ b/test/unit_tests.sh
@@ -480,6 +480,44 @@ testFloatingPointThresholdsExpired() {
 
 }
 
+testFloatingPointThresholdsRecentlyExpired() {
+
+    create_temporary_test_file
+    FAKE_DATE=${TEMPFILE}
+
+    cat <<'EOT' >"${FAKE_DATE}"
+#!/bin/sh
+
+case "$1" in
+    --version)
+        echo 'date (GNU coreutils) 9.0'
+        ;;
+    +%s)
+        echo 1428886799
+        ;;
+    -d)
+        echo 1428883199
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOT
+    chmod +x "${FAKE_DATE}"
+
+    # The fake date reports one hour after the certificate's expiry.
+    # shellcheck disable=SC2086
+    OUTPUT=$(${SCRIPT} ${TEST_DEBUG} -H expired.badssl.com --warning 1.0 --critical 0 --date "${FAKE_DATE}" --first-element-only 2>&1)
+    EXIT_CODE=$?
+    echo "${OUTPUT}"
+
+    assertEquals "wrong exit code" "${NAGIOS_CRITICAL}" "${EXIT_CODE}"
+
+    echo "${OUTPUT}" | grep -q 'less than a day ago'
+    assertEquals "wrong expiry description" 0 $?
+
+}
+
 testFloatingPointThresholdsWrongUsage() {
 
     # shellcheck disable=SC2086


### PR DESCRIPTION
Fixes #562

## Proposed Changes

- Treat negative fractional expiry durations as less than one day old before integer truncation
- Add a deterministic regression for decimal thresholds on a recently expired certificate
- Record the fix in the ChangeLog

## Verification

- Focused shUnit2 regression: 1/1 passed
- Adjacent expiry and floating-threshold tests: 4/4 passed
- `gmake disttest`
- `sh -n check_ssl_cert` and `sh -n test/unit_tests.sh`
- Full ShellCheck, codespell, documentation, man-page, and diff checks

The complete 40-test unit suite was also executed. The new regression passed; six existing macOS/external-environment cases failed locally because of BSD date drift, TLS/file-URI behavior, an external timeout, or a missing Java runtime.